### PR TITLE
General build fixes 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 endif()
 
 # include path for custom modules
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake/modules/)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake/modules/)
 include(Colors)
 
 # get install directories names
@@ -142,7 +142,7 @@ install(
 # add support for find_package()
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
-  ${CMAKE_SOURCE_DIR}/cmake/remageConfig.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/remageConfig.cmake"
+  ${PROJECT_SOURCE_DIR}/cmake/remageConfig.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/remageConfig.cmake"
   INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/remage)
 
 # create version file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(
   remage
   VERSION 0.1.0
   DESCRIPTION "Simulation framework for HPGe-based experiments"
-  LANGUAGES C CXX) # C is needed for GEANT4's HDF5 support
+  LANGUAGES C CXX) # C is needed for Geant4's HDF5 support
 
 message(STATUS "remage version ${CMAKE_PROJECT_VERSION}")
 
@@ -41,43 +41,43 @@ set(RMG_BXDECAY0_MINIMUM_VERSION 1.0.10)
 # Find Geant4
 find_package(Geant4 ${RMG_G4_MINIMUM_VERSION} REQUIRED)
 if(Geant4_FOUND)
-  message(STATUS "Found GEANT4 v" ${Geant4_VERSION})
+  message(STATUS "Found Geant4 v" ${Geant4_VERSION})
 endif()
 
 # check for optional components
 find_package(Geant4 QUIET OPTIONAL_COMPONENTS hdf5 usolids multithreaded gdml ui_all vis_all)
 
 if(Geant4_hdf5_FOUND)
-  message(STATUS "GEANT4 compiled with HDF5 support - enabling feature")
+  message(STATUS "Geant4 compiled with HDF5 support - enabling feature")
   list(APPEND g4_components hdf5)
   list(APPEND remage_components HDF5)
 else()
-  message(STATUS "GEANT4 lacks HDF5 support - disabling feature")
+  message(STATUS "Geant4 lacks HDF5 support - disabling feature")
 endif()
 
 if(Geant4_usolids_FOUND)
-  message(STATUS "GEANT4 compiled with VecGeom support - enabling feature")
+  message(STATUS "Geant4 compiled with VecGeom support - enabling feature")
   list(APPEND g4_components usolids)
   list(APPEND remage_components VecGeom)
 else()
-  message(STATUS "GEANT4 lacks VecGeom support - disabling feature")
+  message(STATUS "Geant4 lacks VecGeom support - disabling feature")
 endif()
 
 if(Geant4_multithreaded_FOUND)
-  message(STATUS "GEANT4 compiled with multithreading support - enabling feature")
+  message(STATUS "Geant4 compiled with multithreading support - enabling feature")
   list(APPEND g4_components multithreaded)
   list(APPEND remage_components Multithreaded)
 else()
-  message(STATUS "GEANT4 lacks multithreading support - disabling feature")
+  message(STATUS "Geant4 lacks multithreading support - disabling feature")
 endif()
 
 if(Geant4_gdml_FOUND)
-  message(STATUS "GEANT4 compiled with GDML support - enabling feature")
+  message(STATUS "Geant4 compiled with GDML support - enabling feature")
   set(RMG_HAS_GDML 1)
   list(APPEND g4_components gdml)
   list(APPEND remage_components GDML)
 else()
-  message(STATUS "GEANT4 lacks GDML support - disabling feature")
+  message(STATUS "Geant4 lacks GDML support - disabling feature")
   set(RMG_HAS_GDML 0)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,8 @@ install(
 # add support for find_package()
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
-  ${PROJECT_SOURCE_DIR}/cmake/remageConfig.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/remageConfig.cmake"
+  ${PROJECT_SOURCE_DIR}/cmake/remageConfig.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/remageConfig.cmake"
   INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/remage)
 
 # create version file

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Simulation framework for germanium detector experiments
 
 <p></p>
 
-The *remage* project aims to provide a modern GEANT4-based C++ library to to
+The *remage* project aims to provide a modern Geant4-based C++ library to to
 efficiently simulate particle physics processes in typical germanium detector
 experiments. The library is setup-agnostic, and therefore the only mandatory
 user action is to provide a geometrical implementation of the experimental

--- a/cmake/ProjectInfo.hh.in
+++ b/cmake/ProjectInfo.hh.in
@@ -1,4 +1,4 @@
-// other useful GEANT4 exported variables:
+// other useful Geant4 exported variables:
 //   G4VIS_USE_<DRIVER>
 //   G4VIS_USE_OPENGLX
 //   G4GEOM_USE_USOLIDS

--- a/cmake/modules/Toolchain.cmake
+++ b/cmake/modules/Toolchain.cmake
@@ -2,7 +2,7 @@
 
 macro(create_mage_toolchain)
   # create and eventually install configuration scripts
-  configure_file(${CMAKE_SOURCE_DIR}/cmake/project-config.in
+  configure_file(${PROJECT_SOURCE_DIR}/cmake/project-config.in
                  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config @ONLY)
 
   # don't install project-config on windows
@@ -12,7 +12,7 @@ macro(create_mage_toolchain)
   endif()
 
   execute_process(COMMAND ${mgdo_CONFIG_EXECUTABLE} --prefix OUTPUT_VARIABLE MGDODIR)
-  set(MAGEDIR ${CMAKE_SOURCE_DIR})
+  set(MAGEDIR ${PROJECT_SOURCE_DIR})
 
   find_program(Geant4_CONFIG_EXECUTABLE geant4-config)
   execute_process(

--- a/include/RMGGeneratorCosmicMuons.hh
+++ b/include/RMGGeneratorCosmicMuons.hh
@@ -33,11 +33,11 @@ class RMGGeneratorCosmicMuons : public RMGVGenerator {
     RMGGeneratorCosmicMuons(RMGGeneratorCosmicMuons&&) = delete;
     RMGGeneratorCosmicMuons& operator=(RMGGeneratorCosmicMuons&&) = delete;
 
-    void GeneratePrimariesKinematics(G4Event* event);
+    void GeneratePrimariesKinematics(G4Event* event) override;
     void SetParticlePosition(G4ThreeVector vec) override{};
 
-    void BeginOfRunAction(const G4Run*);
-    inline void EndOfRunAction(const G4Run*) {}
+    void BeginOfRunAction(const G4Run*) override;
+    inline void EndOfRunAction(const G4Run*) override {}
 
   private:
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 # List here manually all source files. Using GLOB is bad, see:
 # https://cmake.org/cmake/help/latest/command/file.html?highlight=Note#filesystem
 
-set(_root ${CMAKE_SOURCE_DIR})
+set(_root ${PROJECT_SOURCE_DIR})
 
 set(PROJECT_PUBLIC_HEADERS
     ${_root}/include/RMGEventAction.hh
@@ -80,7 +80,7 @@ set_target_properties(remage-cli PROPERTIES OUTPUT_NAME remage)
 # Ensure clients are aware of the minimum C++ standard we were compiled with
 target_compile_features(remage PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
 
-target_include_directories(remage PUBLIC "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include/>"
+target_include_directories(remage PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>"
                                          $<INSTALL_INTERFACE:include>)
 
 # attach project version to shared library
@@ -97,8 +97,8 @@ set_property(
 
 # write ProjectInfo.hh
 # no need to install, it is included in the header list above
-configure_file(${CMAKE_SOURCE_DIR}/cmake/ProjectInfo.hh.in
-               ${CMAKE_SOURCE_DIR}/include/ProjectInfo.hh @ONLY)
+configure_file(${PROJECT_SOURCE_DIR}/cmake/ProjectInfo.hh.in
+               ${PROJECT_SOURCE_DIR}/include/ProjectInfo.hh @ONLY)
 
 # install CMake targets
 install(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,11 @@ set(PROJECT_SOURCES
     ${_root}/src/RMGVertexConfinement.cc
     ${_root}/src/RMGVertexFromFile.cc)
 
+# Write ProjectInfo.hh
+# no need to install, it is included in the header list above
+configure_file(${PROJECT_SOURCE_DIR}/cmake/ProjectInfo.hh.in
+               ${PROJECT_SOURCE_DIR}/include/ProjectInfo.hh @ONLY)
+
 if(BxDecay0_FOUND)
   list(APPEND PROJECT_PUBLIC_HEADERS ${_root}/include/RMGGeneratorDecay0.hh)
 
@@ -60,6 +65,12 @@ if(BxDecay0_FOUND)
 endif()
 
 add_library(remage SHARED ${PROJECT_PUBLIC_HEADERS} ${PROJECT_SOURCES})
+
+# Ensure clients are aware of the minimum C++ standard we were compiled with
+target_compile_features(remage PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
+
+target_include_directories(remage PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>"
+                                         $<INSTALL_INTERFACE:include>)
 
 # link against dependent libraries
 target_link_libraries(remage PUBLIC ${Geant4_LIBRARIES})
@@ -71,11 +82,6 @@ endif()
 if(ROOT_FOUND)
   target_link_libraries(remage PUBLIC ROOT::Core ROOT::Tree ROOT::Hist)
 endif()
-
-# executable for CLI
-add_executable(remage-cli ${_root}/src/remage.cc)
-target_link_libraries(remage-cli PUBLIC remage)
-set_target_properties(remage-cli PROPERTIES OUTPUT_NAME remage)
 
 # Ensure clients are aware of the minimum C++ standard we were compiled with
 target_compile_features(remage PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
@@ -95,10 +101,11 @@ set_property(
   APPEND
   PROPERTY COMPATIBLE_INTERFACE_STRING remage_MAJOR_VERSION)
 
-# write ProjectInfo.hh
-# no need to install, it is included in the header list above
-configure_file(${PROJECT_SOURCE_DIR}/cmake/ProjectInfo.hh.in
-               ${PROJECT_SOURCE_DIR}/include/ProjectInfo.hh @ONLY)
+
+# executable for CLI
+add_executable(remage-cli ${_root}/src/remage.cc)
+target_link_libraries(remage-cli PUBLIC remage)
+set_target_properties(remage-cli PROPERTIES OUTPUT_NAME remage)
 
 # install CMake targets
 install(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,7 +105,6 @@ set_property(
   APPEND
   PROPERTY COMPATIBLE_INTERFACE_STRING remage_MAJOR_VERSION)
 
-
 # executable for CLI
 add_executable(remage-cli ${_root}/src/remage.cc)
 target_link_libraries(remage-cli PUBLIC remage)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,6 +72,10 @@ target_compile_features(remage PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
 target_include_directories(remage PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>"
                                          $<INSTALL_INTERFACE:include>)
 
+# Must use FMT_HEADER_ONLY absolutely everywhere or will get undefined symbols at link time
+# TODO: Use imported target so we can make this transparent and also allow use of external fmt
+target_compile_definitions(remage PUBLIC FMT_HEADER_ONLY)
+
 # link against dependent libraries
 target_link_libraries(remage PUBLIC ${Geant4_LIBRARIES})
 

--- a/src/RMGVertexFromFile.cc
+++ b/src/RMGVertexFromFile.cc
@@ -22,7 +22,7 @@ void RMGVertexFromFile::OpenFile(std::string& name) {
     fReader = G4Hdf5AnalysisReader::Instance();
 #else
     RMGLog::Out(RMGLog::fatal,
-        "HDF5 input not available, please recompile GEANT4 with HDF5 support");
+        "HDF5 input not available, please recompile Geant4 with HDF5 support");
 #endif
   } else if (ext == "csv") fReader = G4CsvAnalysisReader::Instance();
   else if (ext == "xml") fReader = G4XmlAnalysisReader::Instance();


### PR DESCRIPTION
Building remage on macOS Ventura revealed a few issues which this PR aims to address:

- Consistent use of `PROJECT_{SOURCE,BINARY}_DIR` in place of the `CMAKE_...` versions. This is a "nice to have" just in case remage ever gets used as a subproject, and is a little clearer.
- Minor tidy of library CMakeLists.txt so all library commands are together, folllowed by those for executable, and finally install related ones. Again, purely for logic and clarity.
- Add the `FMT_HEADER_ONLY` preprocessing macro _everywhere_ in libremage, and for any target linking to it. On macOS at least, this is needed to prevent undefined symbol errors. Remage _does_ add this in `RMGLog.hh`, but not _everywhere_ `fmt` headers are pulled in.
  - This is a quick fix, longer term it's probably better to create/use a `fmt::fmt` imported target, maybe also hide `fmt` use entirely from the public interface of libremage.
- Fixed a couple of minor warnings for missing `override` on override virtual functions.
- _Very_ pedantic - it's "Geant4" rather than "GEANT4" (wearing by Geant4 🎩 😄 )!   