### PR TITLE
Make EcoMug and BxDecay0 private dependencies

### DIFF
--- a/include/RMGGeneratorCosmicMuons.hh
+++ b/include/RMGGeneratorCosmicMuons.hh
@@ -26,7 +26,7 @@
 #include "G4ParticleGun.hh"
 #include "G4VUserPrimaryGeneratorAction.hh"
 
-#include "EcoMug/EcoMug.h"
+class EcoMug;
 
 namespace u = CLHEP;
 
@@ -41,7 +41,7 @@ class RMGGeneratorCosmicMuons : public RMGVGenerator {
     };
 
     RMGGeneratorCosmicMuons();
-    ~RMGGeneratorCosmicMuons() = default;
+    ~RMGGeneratorCosmicMuons();
 
     RMGGeneratorCosmicMuons(RMGGeneratorCosmicMuons const&) = delete;
     RMGGeneratorCosmicMuons& operator=(RMGGeneratorCosmicMuons const&) = delete;
@@ -56,7 +56,7 @@ class RMGGeneratorCosmicMuons : public RMGVGenerator {
 
   private:
 
-    std::unique_ptr<EcoMug> fEcoMug = nullptr;
+    std::unique_ptr<EcoMug> fEcoMug;
     std::unique_ptr<G4ParticleGun> fGun = nullptr;
 
     std::unique_ptr<G4GenericMessenger> fMessenger = nullptr;

--- a/include/RMGGeneratorDecay0.hh
+++ b/include/RMGGeneratorDecay0.hh
@@ -23,10 +23,9 @@
 
 #include "G4ThreeVector.hh"
 
-#include "ProjectInfo.hh"
-#if RMG_HAS_BXDECAY0
-#include "bxdecay0_g4/primary_generator_action.hh"
-#endif
+namespace bxdecay0_g4 {
+  class PrimaryGeneratorAction;
+}
 
 class G4Event;
 class RMGGeneratorDecay0 : public RMGVGenerator {
@@ -35,7 +34,7 @@ class RMGGeneratorDecay0 : public RMGVGenerator {
 
     RMGGeneratorDecay0(RMGVVertexGenerator* prim_gen);
     RMGGeneratorDecay0() = delete;
-    inline ~RMGGeneratorDecay0() = default;
+    ~RMGGeneratorDecay0();
 
     RMGGeneratorDecay0(RMGGeneratorDecay0 const&) = delete;
     RMGGeneratorDecay0& operator=(RMGGeneratorDecay0 const&) = delete;
@@ -47,7 +46,7 @@ class RMGGeneratorDecay0 : public RMGVGenerator {
 
   private:
 
-    std::unique_ptr<bxdecay0_g4::PrimaryGeneratorAction> fDecay0G4Generator = nullptr;
+    std::unique_ptr<bxdecay0_g4::PrimaryGeneratorAction> fDecay0G4Generator;
 };
 
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,7 +80,7 @@ target_compile_definitions(remage PUBLIC FMT_HEADER_ONLY)
 target_link_libraries(remage PUBLIC ${Geant4_LIBRARIES})
 
 if(BxDecay0_FOUND)
-  target_link_libraries(remage PUBLIC BxDecay0::BxDecay0 BxDecay0::BxDecay0_Geant4)
+  target_link_libraries(remage PRIVATE BxDecay0::BxDecay0 BxDecay0::BxDecay0_Geant4)
 endif()
 
 if(ROOT_FOUND)

--- a/src/RMGGeneratorCosmicMuons.cc
+++ b/src/RMGGeneratorCosmicMuons.cc
@@ -43,6 +43,9 @@ RMGGeneratorCosmicMuons::RMGGeneratorCosmicMuons() : RMGVGenerator("CosmicMuons"
   fGun = std::make_unique<G4ParticleGun>();
 }
 
+// Need non-inline, i.e. not in header/class body, destructor to hide EcoMug from consumers
+RMGGeneratorCosmicMuons::~RMGGeneratorCosmicMuons() = default; // NOLINT
+
 void RMGGeneratorCosmicMuons::BeginOfRunAction(const G4Run*) {
 
   // TODO: get this info from detector construction

--- a/src/RMGGeneratorDecay0.cc
+++ b/src/RMGGeneratorDecay0.cc
@@ -17,6 +17,11 @@
 #include "RMGLog.hh"
 #include "RMGManager.hh"
 
+#include "ProjectInfo.hh"
+#if RMG_HAS_BXDECAY0
+#include "bxdecay0_g4/primary_generator_action.hh"
+#endif
+
 RMGGeneratorDecay0::RMGGeneratorDecay0(RMGVVertexGenerator* prim_gen) : RMGVGenerator("Decay0") {
 
   if (!RMGManager::Instance()->IsExecSequential())
@@ -28,6 +33,9 @@ RMGGeneratorDecay0::RMGGeneratorDecay0(RMGVVertexGenerator* prim_gen) : RMGVGene
   // NOTE: BxDecay0's primary generator action will own the pointer
   fDecay0G4Generator->SetVertexGenerator(prim_gen);
 }
+
+// Need non-inline, i.e. not in header/class body, destructor to hide BXDecay0 from consumers
+RMGGeneratorDecay0::~RMGGeneratorDecay0() = default; // NOLINT
 
 void RMGGeneratorDecay0::GeneratePrimariesKinematics(G4Event* event) {
   fDecay0G4Generator->GeneratePrimaries(event);


### PR DESCRIPTION
Remage's event generators do not provide a public interface that exposes their internals such as EcoMug and BxDecay0. This makes these packages implementation details which a consumer of libremage does not need to be aware of. E.g. a consumer of libremage does _not_ need the EcoMug or BxDecay0 headers to be present, only the runtime library.

This PR uses a "Pimpl/compiler firewall" to hide the EcoMug and BxDecay0 instances from consumers. This does require that non-inline cons/destructors be used, and empty default member initialisation be used for the "Pimpl" `unique_ptr`. Whilst that may not appear elegant, it's a small price for hiding this stuff away (smaller install footprints, potentially faster code) - plus the _default_ constructor for `unique_ptr` is `nullptr` anyway, so largely moot.