### PR TITLE
Starting point/setup for .clang-tidy 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,11 +1,19 @@
+---
+Checks: "-*, \
+  modernize-deprecated-headers, \
+  modernize-make-shared, \
+  modernize-make-unique, \
+  modernize-redundant-void-arg, \
+  modernize-use-auto, \
+  modernize-use-equals-default, \
+  modernize-use-nullptr, \
+  modernize-use-using, \
+  performance-faster-string-find, \
+  performance-for-range-copy, \
+  performance-inefficient-string-concatenation, \
+  performance-trivially-destructible, \
+  readability-delete-null-pointer, \
+  readability-duplicate-include, \
+  readability-string-compare"
 FormatStyle: file
-
-Checks: '
-  modernize-*,
-  performance-*,
-  readability-*,
-  bugprone-*,
-  -modernize-use-trailing-return-type,
-'
-
 HeaderFilterRegex: 'include/.*.hh'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,12 @@ set(CMAKE_INSTALL_LIBDIR lib)
 # Set default build type
 include(BuildType)
 
+# Copy .clang-tidy file to build dir to ensure clang-tidy always picks up the correct one
+# no matter where out build dir is relative to the source dir
+if(EXISTS "${PROJECT_SOURCE_DIR}/.clang-tidy")
+  configure_file("${PROJECT_SOURCE_DIR}/.clang-tidy" "${PROJECT_BINARY_DIR}/.clang-tidy" COPYONLY)
+endif()
+
 # Find dependencies
 set(RMG_G4_MINIMUM_VERSION 11.0.3)
 set(RMG_ROOT_MINIMUM_VERSION 6.06)

--- a/include/RMGGeneratorG4Gun.hh
+++ b/include/RMGGeneratorG4Gun.hh
@@ -30,7 +30,7 @@ class RMGGeneratorG4Gun : public RMGVGenerator {
   public:
 
     inline RMGGeneratorG4Gun() : RMGVGenerator("G4Gun") {
-      fParticleGun = std::unique_ptr<G4ParticleGun>(new G4ParticleGun());
+      fParticleGun = std::make_unique<G4ParticleGun>();
     }
     inline ~RMGGeneratorG4Gun() = default;
 

--- a/include/RMGGeneratorGPS.hh
+++ b/include/RMGGeneratorGPS.hh
@@ -28,7 +28,7 @@ class RMGGeneratorGPS : public RMGVGenerator {
   public:
 
     inline RMGGeneratorGPS() : RMGVGenerator("GPS") {
-      fParticleSource = std::unique_ptr<G4GeneralParticleSource>(new G4GeneralParticleSource());
+      fParticleSource = std::make_unique<G4GeneralParticleSource>();
     }
 
     inline ~RMGGeneratorGPS() = default;

--- a/include/RMGGermaniumDetector.hh
+++ b/include/RMGGermaniumDetector.hh
@@ -51,7 +51,7 @@ class RMGGermaniumDetectorHit : public G4VHit {
     double global_time = -1;
 };
 
-typedef G4THitsCollection<RMGGermaniumDetectorHit> RMGGermaniumDetectorHitsCollection;
+using RMGGermaniumDetectorHitsCollection = G4THitsCollection<RMGGermaniumDetectorHit>;
 
 class G4Step;
 class G4HCofThisEvent;

--- a/include/RMGOpticalDetector.hh
+++ b/include/RMGOpticalDetector.hh
@@ -51,7 +51,7 @@ class RMGOpticalDetectorHit : public G4VHit {
     double global_time = -1;
 };
 
-typedef G4THitsCollection<RMGOpticalDetectorHit> RMGOpticalDetectorHitsCollection;
+using RMGOpticalDetectorHitsCollection = G4THitsCollection<RMGOpticalDetectorHit>;
 
 class G4Step;
 class G4HCofThisEvent;

--- a/src/RMGGeneratorCosmicMuons.cc
+++ b/src/RMGGeneratorCosmicMuons.cc
@@ -15,7 +15,7 @@
 
 #include "RMGGeneratorCosmicMuons.hh"
 
-#include "math.h"
+#include <cmath>
 
 #include "G4GenericMessenger.hh"
 #include "G4ParticleGun.hh"

--- a/src/RMGGermaniumDetector.cc
+++ b/src/RMGGermaniumDetector.cc
@@ -119,7 +119,7 @@ bool RMGGermaniumDetector::ProcessHits(G4Step* step, G4TouchableHistory* /*histo
   RMGLog::OutDev(RMGLog::debug, "Hit in germanium detector nr. ", det_uid, " detected");
 
   // create a new hit and fill it
-  RMGGermaniumDetectorHit* hit = new RMGGermaniumDetectorHit();
+  auto* hit = new RMGGermaniumDetectorHit();
   hit->detector_uid = det_uid;
   hit->energy_deposition = step->GetTotalEnergyDeposit();
   hit->global_position = prestep->GetPosition();

--- a/src/RMGOpticalDetector.cc
+++ b/src/RMGOpticalDetector.cc
@@ -104,7 +104,7 @@ bool RMGOpticalDetector::ProcessHits(G4Step* step, G4TouchableHistory* /*history
   RMGLog::OutDev(RMGLog::debug, "Hit in optical detector nr. ", det_uid, " detected");
 
   // initialize hit object for uid, if not already there
-  RMGOpticalDetectorHit* hit = new RMGOpticalDetectorHit();
+  auto* hit = new RMGOpticalDetectorHit();
   hit->detector_uid = det_uid;
   hit->photon_wavelength = CLHEP::c_light * CLHEP::h_Planck / step->GetTotalEnergyDeposit();
   hit->global_time = step->GetPreStepPoint()->GetGlobalTime();


### PR DESCRIPTION
As a follow up to #31, this demos a minimal `.clang-tidy` file with a small set of checks. These are _somewhat_ arbitrary, but generally work well and are safe to apply automatically (if that is desired). It's split into two commits to separate out:

1. The `.clang-tidy` change itself. This also includes a minor CMake update that copies the `.clang-tidy` file from source to build directory. LLVM's `run-clang-tidy` script is nominally supposed to find this in the source directory, but I've found this slightly flaky. Given that a model for operation is to use `run-clang-tidy` in the (or point it to the) build directory only, copying the config file here is generally reliable (to be reviewed though!).
2. The second commit shows what happens to the code after a `run-clang-tidy -fix -format` operation with the updated config file. Pretty minimal as expected, but shows it works!

This is of course just a demo, so fixes/updates etc very welcome. There are of course _plenty_ of additional checks that could be applied, but perhaps this is something to do step-by-step in future PRs. Some are "obvious" but may not always work nicely with the `-fix` optional without developer intervention.
