### PR TITLE
Remove support for vertex sampling with a bounding sphere

### DIFF
--- a/include/RMGGeneratorCosmicMuons.hh
+++ b/include/RMGGeneratorCosmicMuons.hh
@@ -30,7 +30,6 @@ class EcoMug;
 
 namespace u = CLHEP;
 
-// TODO: must inherit from RMGVGenerator
 class RMGGeneratorCosmicMuons : public RMGVGenerator {
 
   public:
@@ -49,7 +48,7 @@ class RMGGeneratorCosmicMuons : public RMGVGenerator {
     RMGGeneratorCosmicMuons& operator=(RMGGeneratorCosmicMuons&&) = delete;
 
     void GeneratePrimaries(G4Event* event) override;
-    void SetParticlePosition(G4ThreeVector vec) override{};
+    void SetParticlePosition(G4ThreeVector) override {}
 
     void BeginOfRunAction(const G4Run*) override;
     inline void EndOfRunAction(const G4Run*) override {}

--- a/include/RMGHardware.hh
+++ b/include/RMGHardware.hh
@@ -72,7 +72,9 @@ class RMGHardware : public G4VUserDetectorConstruction {
 
   private:
 
+    /// List of GDML files to load
     std::vector<std::string> fGDMLFiles;
+    /// Mapping between physical volume names and maximum (user) step size to apply
     std::map<std::string, double> fPhysVolStepLimits;
 
     // one element for each sensitive detector physical volume
@@ -82,7 +84,12 @@ class RMGHardware : public G4VUserDetectorConstruction {
     std::unique_ptr<G4GenericMessenger> fMessenger;
     void DefineCommands();
 
+    /// The world volume
     G4VPhysicalVolume* fWorld = nullptr;
+
+    /** Region used to assign special production cuts
+     *  for sensitive volumes. Logical volumes of sensitive volumes should be
+     *  added to it. */
     G4Region* fSensitiveRegion = new G4Region("SensitiveRegion");
 };
 

--- a/include/RMGVertexConfinement.hh
+++ b/include/RMGVertexConfinement.hh
@@ -72,7 +72,6 @@ class RMGVertexConfinement : public RMGVVertexGenerator {
     void Reset();
 
     inline void SetSamplingMode(SamplingMode mode) { fSamplingMode = mode; }
-    inline void SetBoundingSolidType(std::string type) { fBoundingSolidType = type; }
 
     inline std::vector<GenericGeometricalSolidData>& GetGeometricalSolidDataList() {
       return fGeomVolumeData;
@@ -137,7 +136,6 @@ class RMGVertexConfinement : public RMGVVertexGenerator {
 
     SamplingMode fSamplingMode = kUnionAll;
     bool fOnSurface = false;
-    std::string fBoundingSolidType = "Box";
     long fTrials = 0;
 
     std::vector<std::unique_ptr<G4GenericMessenger>> fMessengers;

--- a/src/RMGHardware.cc
+++ b/src/RMGHardware.cc
@@ -59,6 +59,7 @@ G4VPhysicalVolume* RMGHardware::Construct() {
 
   // TODO: build and return world volume?
 
+  // attach user max step sizes to logical volumes
   for (const auto& el : fPhysVolStepLimits) {
     RMGLog::OutFormat(RMGLog::debug, "Setting max user step size for volume '{}' to {}", el.first,
         el.second);

--- a/src/RMGPhysics.cc
+++ b/src/RMGPhysics.cc
@@ -251,10 +251,6 @@ void RMGPhysics::SetCuts() {
   this->SetCutValue(fStepCuts.electron, "e-");
   this->SetCutValue(fStepCuts.positron, "e+");
   this->SetCutValue(fStepCuts.proton, "proton");
-  this->SetCutValue(fStepCuts.alpha, "alpha");
-  this->SetCutValue(fStepCuts.muon, "mu+");
-  this->SetCutValue(fStepCuts.muon, "mu-");
-  this->SetCutValue(fStepCuts.generic_ion, "GenericIon");
 
   // set different cuts for the sensitive region
   // the G4Region "SensitiveRegion" is created in RMGHardware, but this
@@ -270,8 +266,6 @@ void RMGPhysics::SetCuts() {
     cuts->SetProductionCut(fStepCutsSensitive.electron, "e-");
     cuts->SetProductionCut(fStepCutsSensitive.positron, "e+");
     cuts->SetProductionCut(fStepCutsSensitive.proton, "proton");
-    cuts->SetProductionCut(fStepCutsSensitive.alpha, "alpha");
-    cuts->SetProductionCut(fStepCutsSensitive.generic_ion, "GenericIon");
     region->SetProductionCuts(cuts);
   } else {
     RMGLog::Out(RMGLog::warning, "Could not find G4Region 'SensitiveRegion' in the store. ",
@@ -316,13 +310,10 @@ void RMGPhysics::SetPhysicsRealm(PhysicsRealm realm) {
     case RMGPhysics::PhysicsRealm::kCosmicRays:
       RMGLog::Out(RMGLog::summary, "Realm set to CosmicRays (cut-per-region)");
       fStepCuts = StepCutStore(G4VUserPhysicsList::defaultCutValue);
-      fStepCuts.muon = 3 * u::cm;
       fStepCuts.gamma = 5 * u::cm;
       fStepCuts.electron = 1 * u::cm;
       fStepCuts.positron = 1 * u::cm;
       fStepCuts.proton = 5 * u::mm;
-      fStepCuts.alpha = 5 * u::mm;
-      fStepCuts.generic_ion = 5 * u::mm;
 
       fStepCutsSensitive = StepCutStore(G4VUserPhysicsList::defaultCutValue);
       fStepCutsSensitive.gamma = 30 * u::mm;

--- a/src/RMGVertexConfinement.cc
+++ b/src/RMGVertexConfinement.cc
@@ -249,6 +249,8 @@ void RMGVertexConfinement::InitializePhysicalVolumes() {
       // function does not cache the result!
       solid->BoundingLimits(lim_min, lim_max);
 
+      RMGLog::OutDev(RMGLog::debug, "Bounding box coordinates: min = ", lim_min, ", max = ", lim_max);
+
       el.sampling_solid =
           new G4Box(el.physical_volume->GetName() + "/RMGVertexConfinement::fBoundingBox",
               lim_max.getX() - lim_min.getX(), lim_max.getY() - lim_min.getY(),

--- a/tests/confinement/macros/complex-volume.mac
+++ b/tests/confinement/macros/complex-volume.mac
@@ -1,8 +1,8 @@
 /control/execute macros/vis.mac
 
-/RMG/Generator/Confine Volume
+/RMG/Manager/Logging/LogLevel detail
 
-/RMG/Generator/Confinement/FallbackBoundingVolumeType Sphere # or Box
+/RMG/Generator/Confine Volume
 
 /RMG/Generator/Confinement/Physical/AddVolume BoxWithHole
 /RMG/Generator/Confinement/Physical/AddVolume BoxAndOrb

--- a/tests/confinement/macros/complex-volume.mac
+++ b/tests/confinement/macros/complex-volume.mac
@@ -1,7 +1,5 @@
 /control/execute macros/vis.mac
 
-/RMG/Manager/Logging/LogLevel detail
-
 /RMG/Generator/Confine Volume
 
 /RMG/Generator/Confinement/Physical/AddVolume BoxWithHole

--- a/tests/confinement/macros/vis.mac
+++ b/tests/confinement/macros/vis.mac
@@ -2,7 +2,7 @@
 
 # /RMG/Manager/Logging/LogLevel detail
 
-/vis/open OGL
+/vis/open OI
 /vis/drawVolume
 /vis/sceneHandler/attach
 

--- a/tests/confinement/macros/vis.mac
+++ b/tests/confinement/macros/vis.mac
@@ -1,8 +1,8 @@
 /run/initialize
 
-# /RMG/Manager/Logging/LogLevel detail
+/RMG/Manager/Logging/LogLevel debug
 
-/vis/open OI
+/vis/open OGL
 /vis/drawVolume
 /vis/sceneHandler/attach
 


### PR DESCRIPTION
The bounding box is always more efficient:

https://github.com/Geant4/geant4/blob/dd1f179cda58f54140945ad67846ff417903a862/source/graphics_reps/src/G4VisExtent.cc#L75-L83