### PR TITLE
Add command /RMG/Geometry/RegisterDetector

### DIFF
--- a/include/RMGHardware.hh
+++ b/include/RMGHardware.hh
@@ -26,6 +26,7 @@
 #include "G4Region.hh"
 #include "G4VUserDetectorConstruction.hh"
 
+#include "RMGHardwareMessenger.hh"
 #include "RMGNavigationTools.hh"
 
 class G4VPhysicalVolume;
@@ -56,6 +57,7 @@ class RMGHardware : public G4VUserDetectorConstruction {
     };
 
     void RegisterDetector(DetectorType type, const std::string& pv_name, int uid, int copy_nr = 0);
+    void RegisterDetectorCmd(const std::string& parameters);
     inline const auto& GetDetectorMetadataMap() { return fDetectorMetadata; }
     inline const auto& GetDetectorMetadata(std::pair<std::string, int> det) {
       return fDetectorMetadata.at(det);
@@ -80,8 +82,10 @@ class RMGHardware : public G4VUserDetectorConstruction {
     // one element for each sensitive detector physical volume
     std::map<std::pair<std::string, int>, DetectorMetadata> fDetectorMetadata;
     std::set<DetectorType> fActiveDetectors;
+    bool fActiveDetectorsInitialized = false;
 
     std::unique_ptr<G4GenericMessenger> fMessenger;
+    std::unique_ptr<RMGHardwareMessenger> fHwMessenger;
     void DefineCommands();
 
     /// The world volume

--- a/include/RMGHardwareMessenger.hh
+++ b/include/RMGHardwareMessenger.hh
@@ -1,0 +1,39 @@
+// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option) any
+// later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef _RMG_HARDWARE_MESSENGER_HH_
+#define _RMG_HARDWARE_MESSENGER_HH_
+
+#include "G4UImessenger.hh"
+
+class RMGHardware;
+class RMGHardwareMessenger : public G4UImessenger {
+
+  public:
+
+    RMGHardwareMessenger(RMGHardware* hw);
+    ~RMGHardwareMessenger();
+
+    void SetNewValue(G4UIcommand* command, G4String newValues);
+
+  private:
+
+    RMGHardware* fHardware;
+    G4UIcommand* fRegisterCmd;
+};
+
+#endif
+
+// vim: tabstop=2 shiftwidth=2 expandtab

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ set(PROJECT_PUBLIC_HEADERS
 
 set(PROJECT_SOURCES
     ${_root}/src/RMGHardware.cc
+    ${_root}/src/RMGHardwareMessenger.cc
     ${_root}/src/RMGEventAction.cc
     ${_root}/src/RMGGeneratorCosmicMuons.cc
     ${_root}/src/RMGGeneratorUtil.cc

--- a/src/RMGHardwareMessenger.cc
+++ b/src/RMGHardwareMessenger.cc
@@ -1,0 +1,52 @@
+// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option) any
+// later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "RMGHardwareMessenger.hh"
+
+#include "RMGHardware.hh"
+
+#ifndef FMT_HEADER_ONLY
+#define FMT_HEADER_ONLY
+#endif
+#include "fmt/core.h"
+#include "magic_enum/magic_enum.hpp"
+
+RMGHardwareMessenger::RMGHardwareMessenger(RMGHardware* hw) : fHardware(hw) {
+  auto detector_types = magic_enum::enum_names<RMGHardware::DetectorType>();
+  auto options = fmt::format("{}", fmt::join(detector_types, "|"));
+
+  fRegisterCmd = new G4UIcommand("/RMG/Geometry/RegisterDetector", this);
+  fRegisterCmd->SetGuidance("register a sensitive detector");
+  fRegisterCmd->SetGuidance("[usage] /RMG/Geometry/RegisterDetector T PV ID [C]");
+  fRegisterCmd->SetGuidance(fmt::format("        T:(str) {}", options).c_str());
+  fRegisterCmd->SetGuidance("        PV:(s) physvol");
+  fRegisterCmd->SetGuidance("        ID:(int) unique detector id");
+  fRegisterCmd->SetGuidance("        C:(int) copy nr (default 0)");
+
+  fRegisterCmd->SetParameter(new G4UIparameter("type", 's', false));
+  fRegisterCmd->SetParameter(new G4UIparameter("pv_name", 's', false));
+  fRegisterCmd->SetParameter(new G4UIparameter("uid", 'i', false));
+  fRegisterCmd->SetParameter(new G4UIparameter("copy_nr", 'i', true));
+
+  fRegisterCmd->AvailableForStates(G4State_PreInit);
+}
+
+RMGHardwareMessenger::~RMGHardwareMessenger() { delete fRegisterCmd; }
+
+void RMGHardwareMessenger::SetNewValue(G4UIcommand* command, G4String newValues) {
+  if (command == fRegisterCmd) fHardware->RegisterDetectorCmd(newValues);
+}
+
+// vim: tabstop=2 shiftwidth=2 expandtab


### PR DESCRIPTION
* We need our own messenger for this, as `G4GenericMessenger` only supports binding to functions with <= 2 arguments.
* This also adds a safeguard against changing the list of active detectors after the detector has been constructed. Until now this silently failed/did nothing.
  This problem cannot be reached by the new command (it is bound to the `PreInit` state), but could be reached by custom C++ code.