### PR TITLE
Setup analysis manager later and fix muti threaded runs

### DIFF
--- a/include/RMGRunAction.hh
+++ b/include/RMGRunAction.hh
@@ -59,6 +59,7 @@ class RMGRunAction : public G4UserRunAction {
 
     RMGRun* fRMGRun = nullptr;
     bool fIsPersistencyEnabled = false;
+    bool fIsAnaManInitialized = false;
     RMGMasterGenerator* fRMGMasterGenerator = nullptr;
 
     std::map<RMGHardware::DetectorType, std::unique_ptr<RMGVOutputScheme>> fOutputDataFields;

--- a/src/RMGGermaniumOutputScheme.cc
+++ b/src/RMGGermaniumOutputScheme.cc
@@ -84,13 +84,10 @@ void RMGGermaniumOutputScheme::EndOfEventAction(const G4Event* event) {
       if (!hit) continue;
       hit->Print();
 
-      const auto evt = rmg_man->GetG4RunManager()->GetCurrentEvent();
-      if (!evt) RMGLog::OutDev(RMGLog::fatal, "Current event is nullptr, this should not happen!");
-
       const auto ana_man = G4AnalysisManager::Instance();
       auto ntupleid = rmg_man->GetNtupleID(hit->detector_uid);
 
-      ana_man->FillNtupleIColumn(ntupleid, 0, evt->GetEventID());
+      ana_man->FillNtupleIColumn(ntupleid, 0, event->GetEventID());
       ana_man->FillNtupleDColumn(ntupleid, 1, hit->energy_deposition / u::keV);
       ana_man->FillNtupleDColumn(ntupleid, 2, hit->global_time / u::ns);
       ana_man->FillNtupleDColumn(ntupleid, 3, hit->global_position.getX() / u::m);

--- a/src/RMGOpticalOutputScheme.cc
+++ b/src/RMGOpticalOutputScheme.cc
@@ -81,13 +81,10 @@ void RMGOpticalOutputScheme::EndOfEventAction(const G4Event* event) {
       if (!hit) continue;
       hit->Print();
 
-      const auto evt = rmg_man->GetG4RunManager()->GetCurrentEvent();
-      if (!evt) RMGLog::OutDev(RMGLog::fatal, "Current event is nullptr, this should not happen!");
-
       auto ntupleid = rmg_man->GetNtupleID(hit->detector_uid);
 
       const auto ana_man = G4AnalysisManager::Instance();
-      ana_man->FillNtupleIColumn(ntupleid, 0, evt->GetEventID());
+      ana_man->FillNtupleIColumn(ntupleid, 0, event->GetEventID());
       ana_man->FillNtupleDColumn(ntupleid, 1, hit->photon_wavelength / u::nm);
       ana_man->FillNtupleDColumn(ntupleid, 2, hit->global_time / u::ns);
 

--- a/src/RMGRunAction.cc
+++ b/src/RMGRunAction.cc
@@ -65,8 +65,7 @@ void RMGRunAction::SetupAnalysisManager() {
   if (RMGLog::GetLogLevel() <= RMGLog::debug) ana_man->SetVerboseLevel(10);
   else ana_man->SetVerboseLevel(0);
 
-  if (!RMGManager::Instance()->IsExecSequential()) ana_man->SetNtupleMerging(true);
-  else ana_man->SetNtupleMerging(false);
+  ana_man->SetNtupleMerging(!RMGManager::Instance()->IsExecSequential());
 
   // do it only for activated detectors (have to ask to the manager)
   auto det_cons = RMGManager::Instance()->GetDetectorConstruction();

--- a/src/RMGRunAction.cc
+++ b/src/RMGRunAction.cc
@@ -39,19 +39,15 @@ G4Run* RMGRunAction::GenerateRun() {
   return fRMGRun;
 }
 
-RMGRunAction::RMGRunAction(bool persistency) : fIsPersistencyEnabled(persistency) {
-
-  if (fIsPersistencyEnabled) { this->SetupAnalysisManager(); }
-}
+RMGRunAction::RMGRunAction(bool persistency) : fIsPersistencyEnabled(persistency) {}
 
 RMGRunAction::RMGRunAction(RMGMasterGenerator* gene, bool persistency)
-    : fIsPersistencyEnabled(persistency), fRMGMasterGenerator(gene) {
+    : fIsPersistencyEnabled(persistency), fRMGMasterGenerator(gene) {}
 
-  if (fIsPersistencyEnabled) { this->SetupAnalysisManager(); }
-}
-
-// called in the run action constructor
+// called at the begin of the run action.
 void RMGRunAction::SetupAnalysisManager() {
+  if (fIsAnaManInitialized) return;
+  fIsAnaManInitialized = true;
 
   auto rmg_man = RMGManager::Instance();
   if (rmg_man->GetDetectorConstruction()->GetActiveDetectorList().empty()) {
@@ -103,6 +99,9 @@ void RMGRunAction::BeginOfRunAction(const G4Run*) {
 
   auto manager = RMGManager::Instance();
 
+  if (fIsPersistencyEnabled) this->SetupAnalysisManager();
+
+  // Check again, SetupAnalysisManager might have modified fIsPersistencyEnabled.
   if (fIsPersistencyEnabled) {
     auto ana_man = G4AnalysisManager::Instance();
     // TODO: realpath


### PR DESCRIPTION
* Initializing the G4AnalysisManager in the run action constructor is too early; at this point no information on registered detectors is available, and the analysis manager will essentially stay empty.
This will lead to a crash after simulating the first event, when trying to store its hit data.

  The macro files are (and have to, see #20 !) loaded after the setup of the run action. Deferring the setup of the analysis manager to the begin of the actual run fixes this issue.

* This PR also introduces a new flag to stop the analysis manager from being set up twice (when using multiple runs?).
* `RMGManager::RegisterNtuple` is called from worker threads and should not complain if they try to register the same ntuple again.
   The error is now only generated if the master thread tries to register an ntuple twice.
* remove the dedicated call to get the current event in the output schemes.
   `rmg_man->GetG4RunManager()->GetCurrentEvent();` should be the master run manager, and will return a `nullptr`.