### PR TITLE
Misc fixes

### DIFF
--- a/cmake/RMGConfig.hh.in
+++ b/cmake/RMGConfig.hh.in
@@ -1,5 +1,5 @@
-#ifndef _RMGCONFIG_HH_
-#define _RMGCONFIG_HH_
+#ifndef _RMG_CONFIG_HH_
+#define _RMG_CONFIG_HH_
 
 // other useful Geant4 exported variables:
 //   G4VIS_USE_<DRIVER>

--- a/include/RMGEventAction.hh
+++ b/include/RMGEventAction.hh
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef _RMG_MANAGEMENT_EVENT_ACTION_HH_
-#define _RMG_MANAGEMENT_EVENT_ACTION_HH_
+#ifndef _RMG_EVENT_ACTION_HH_
+#define _RMG_EVENT_ACTION_HH_
 
 #include <memory>
 

--- a/include/RMGGeneratorG4Gun.hh
+++ b/include/RMGGeneratorG4Gun.hh
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef _RMGGENERATORG4GUN_HH_
-#define _RMGGENERATORG4GUN_HH_
+#ifndef _RMG_GENERATOR_G4GUN_HH_
+#define _RMG_GENERATOR_G4GUN_HH_
 
 #include <memory>
 

--- a/include/RMGHardware.hh
+++ b/include/RMGHardware.hh
@@ -57,7 +57,6 @@ class RMGHardware : public G4VUserDetectorConstruction {
     };
 
     void RegisterDetector(DetectorType type, const std::string& pv_name, int uid, int copy_nr = 0);
-    void RegisterDetectorCmd(const std::string& parameters);
     inline const auto& GetDetectorMetadataMap() { return fDetectorMetadata; }
     inline const auto& GetDetectorMetadata(std::pair<std::string, int> det) {
       return fDetectorMetadata.at(det);

--- a/include/RMGHardware.hh
+++ b/include/RMGHardware.hh
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef _RMG_MANAGEMENT_DETECTOR_CONSTRUCTION_HH_
-#define _RMG_MANAGEMENT_DETECTOR_CONSTRUCTION_HH_
+#ifndef _RMG_HARDWARE_HH_
+#define _RMG_HARDWARE_HH_
 
 #include <map>
 #include <memory>

--- a/include/RMGHardwareMessenger.hh
+++ b/include/RMGHardwareMessenger.hh
@@ -32,6 +32,8 @@ class RMGHardwareMessenger : public G4UImessenger {
 
     RMGHardware* fHardware;
     G4UIcommand* fRegisterCmd;
+
+    void RegisterDetectorCmd(const std::string& parameters);
 };
 
 #endif

--- a/include/RMGLog.hh
+++ b/include/RMGLog.hh
@@ -1,7 +1,7 @@
 // Modified by Luigi Pertoldi <gipert@pm.me> in 2022
 
-#ifndef _RMGLOG_HH_
-#define _RMGLOG_HH_
+#ifndef _RMG_LOG_HH_
+#define _RMG_LOG_HH_
 
 /**
  * @class RMGLog

--- a/include/RMGMasterGenerator.hh
+++ b/include/RMGMasterGenerator.hh
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef _RMG_GENERATOR_PRIMARY_HH_
-#define _RMG_GENERATOR_PRIMARY_HH_
+#ifndef _RMG_MASTER_GENERATOR_HH_
+#define _RMG_MASTER_GENERATOR_HH_
 
 #include <memory>
 

--- a/include/RMGPhysics.hh
+++ b/include/RMGPhysics.hh
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef _RMG_PROCESSES_LIST_HH_
-#define _RMG_PROCESSES_LIST_HH_
+#ifndef _RMG_PHYSICS_HH_
+#define _RMG_PHYSICS_HH_
 
 #include <map>
 #include <memory>

--- a/include/RMGRunAction.hh
+++ b/include/RMGRunAction.hh
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef _RMG_MANAGEMENT_RUN_ACTION_HH_
-#define _RMG_MANAGEMENT_RUN_ACTION_HH_
+#ifndef _RMG_RUN_ACTION_HH_
+#define _RMG_RUN_ACTION_HH_
 
 #include <chrono>
 #include <map>

--- a/include/RMGStackingAction.hh
+++ b/include/RMGStackingAction.hh
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef _RMG_MANAGEMENT_STACKING_ACTION_HH_
-#define _RMG_MANAGEMENT_STACKING_ACTION_HH_
+#ifndef _RMG_STACKING_ACTION_HH_
+#define _RMG_STACKING_ACTION_HH_
 
 #include "G4UserStackingAction.hh"
 

--- a/include/RMGSteppingAction.hh
+++ b/include/RMGSteppingAction.hh
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef _RMG_MANAGEMENT_STEPPING_ACTION_HH_
-#define _RMG_MANAGEMENT_STEPPING_ACTION_HH_
+#ifndef _RMG_STEPPING_ACTION_HH_
+#define _RMG_STEPPING_ACTION_HH_
 
 #include "G4UserSteppingAction.hh"
 

--- a/include/RMGTools.hh
+++ b/include/RMGTools.hh
@@ -23,10 +23,6 @@
 #include <vector>
 
 namespace RMGTools {
-
-  template<typename T> T ToEnum(std::string);
-
-  template<typename T> std::string GetCandidates();
 } // namespace RMGTools
 
 #include "RMGTools.icc"

--- a/include/RMGTools.hh
+++ b/include/RMGTools.hh
@@ -16,8 +16,7 @@
 #ifndef _RMG_TOOLS_HH_
 #define _RMG_TOOLS_HH_
 
-namespace RMGTools {
-} // namespace RMGTools
+namespace RMGTools {} // namespace RMGTools
 
 #include "RMGTools.icc"
 

--- a/include/RMGTools.hh
+++ b/include/RMGTools.hh
@@ -16,12 +16,6 @@
 #ifndef _RMG_TOOLS_HH_
 #define _RMG_TOOLS_HH_
 
-#include <chrono>
-#include <ctime>
-#include <memory>
-#include <utility>
-#include <vector>
-
 namespace RMGTools {
 } // namespace RMGTools
 

--- a/include/RMGTools.icc
+++ b/include/RMGTools.icc
@@ -34,12 +34,12 @@ namespace RMGTools {
     }
 
     template <typename T>
-    std::string GetCandidates() {
+    std::string GetCandidates(const char delim=' ') {
         auto v = magic_enum::enum_names<T>();
         std::string cand = "";
         for (const auto& s : v) {
             auto name = s[0] == 'k' ? s.substr(1, std::string::npos) : s;
-            cand += std::string(name) + " ";
+            cand += std::string(name) + delim;
         }
         return cand.substr(0, cand.size()-1);
     }

--- a/include/RMGTrackingAction.hh
+++ b/include/RMGTrackingAction.hh
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef _RMG_MANAGEMENT_TRACKING_ACTION_HH_
-#define _RMG_MANAGEMENT_TRACKING_ACTION_HH_
+#ifndef _RMG_TRACKING_ACTION_HH_
+#define _RMG_TRACKING_ACTION_HH_
 
 #include "G4UserTrackingAction.hh"
 

--- a/include/RMGUserAction.hh
+++ b/include/RMGUserAction.hh
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef _RMG_MANAGEMENT_USER_ACTION_HH_
-#define _RMG_MANAGEMENT_USER_ACTION_HH_
+#ifndef _RMG_USER_ACTION_HH_
+#define _RMG_USER_ACTION_HH_
 
 #include "G4VUserActionInitialization.hh"
 

--- a/include/RMGVGenerator.hh
+++ b/include/RMGVGenerator.hh
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef _RMGVGENERATOR_HH_
-#define _RMGVGENERATOR_HH_
+#ifndef _RMG_V_GENERATOR_HH_
+#define _RMG_V_GENERATOR_HH_
 
 #include <memory>
 

--- a/include/RMGVOutputScheme.hh
+++ b/include/RMGVOutputScheme.hh
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef _RMG_OUTPUT_SCHEME_HH_
-#define _RMG_OUTPUT_SCHEME_HH_
+#ifndef _RMG_V_OUTPUT_SCHEME_HH_
+#define _RMG_V_OUTPUT_SCHEME_HH_
 
 #include <map>
 #include <string>

--- a/include/RMGVVertexGenerator.hh
+++ b/include/RMGVVertexGenerator.hh
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef _RMG_GENERATOR_PRIMARY_POSITION_HH_
-#define _RMG_GENERATOR_PRIMARY_POSITION_HH_
+#ifndef _RMG_V_VERTEX_GENERARTOR_HH_
+#define _RMG_V_VERTEX_GENERARTOR_HH_
 
 #include "RMGConfig.hh"
 #if RMG_HAS_BXDECAY0

--- a/include/RMGVertexFromFile.hh
+++ b/include/RMGVertexFromFile.hh
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef _RMG_GENERATOR_FROM_FILE_HH_
-#define _RMG_GENERATOR_FROM_FILE_HH_
+#ifndef _RMG_VERTEX_FROM_FILE_HH_
+#define _RMG_VERTEX_FROM_FILE_HH_
 
 #include <memory>
 #include <string>

--- a/src/RMGHardware.cc
+++ b/src/RMGHardware.cc
@@ -23,8 +23,6 @@ namespace fs = std::filesystem;
 #include "G4LogicalVolume.hh"
 #include "G4PhysicalVolumeStore.hh"
 #include "G4SDManager.hh"
-#include "G4Tokenizer.hh"
-#include "G4UIparameter.hh"
 #include "G4UserLimits.hh"
 #include "G4VPhysicalVolume.hh"
 
@@ -185,24 +183,6 @@ void RMGHardware::RegisterDetector(DetectorType type, const std::string& pv_name
         "Registered physical volume '{}' (copy nr. {}) as {} detector type", pv_name, copy_nr,
         magic_enum::enum_name(type));
   }
-}
-
-void RMGHardware::RegisterDetectorCmd(const std::string& parameters) {
-  G4Tokenizer next(parameters);
-
-  auto type_str = next();
-  auto type = magic_enum::enum_cast<DetectorType>(type_str);
-  if (!type.has_value()) {
-    RMGLog::OutFormat(RMGLog::error, "Invalid detector type {} in command", type_str);
-    return;
-  }
-  auto pv_name = next();
-  const int uid = std::stoi(next());
-  int copy_nr = 0;
-  auto copy_nr_str = next();
-  if (!copy_nr_str.empty()) copy_nr = std::stoi(copy_nr_str);
-
-  this->RegisterDetector(type.value(), pv_name, uid, copy_nr);
 }
 
 void RMGHardware::DefineCommands() {

--- a/src/RMGManager.cc
+++ b/src/RMGManager.cc
@@ -259,11 +259,6 @@ void RMGManager::DefineCommands() {
   fMessenger = std::make_unique<G4GenericMessenger>(this, "/RMG/Manager/",
       "General commands for controlling the application");
 
-  fMessenger->DeclareMethod("Include", &RMGManager::IncludeMacroFile)
-      .SetGuidance("Include macro file")
-      .SetParameterName("filename", false)
-      .SetStates(G4State_PreInit, G4State_Idle);
-
   fMessenger->DeclareMethod("Interactive", &RMGManager::SetInteractive)
       .SetGuidance("Enable interactive mode")
       .SetParameterName("flag", true)

--- a/src/RMGPhysics.cc
+++ b/src/RMGPhysics.cc
@@ -359,12 +359,12 @@ void RMGPhysics::DefineCommands() {
 
   fMessenger->DeclareProperty("OpticalPhysics", fConstructOptical)
       .SetGuidance("Add optical processes to the physics list")
-      .SetStates(G4State_PreInit, G4State_Idle);
+      .SetStates(G4State_PreInit);
 
   fMessenger->DeclareMethod("LowEnergyEMPhysics", &RMGPhysics::SetLowEnergyEMOptionString)
       .SetGuidance("Add low energy electromagnetic processes to the physics list")
       .SetCandidates(RMGTools::GetCandidates<RMGPhysics::LowEnergyEMOption>())
-      .SetStates(G4State_PreInit, G4State_Idle);
+      .SetStates(G4State_PreInit);
 
   fMessenger->DeclareMethod("EnableGammaAngularCorrelation", &RMGPhysics::SetUseGammaAngCorr)
       .SetGuidance("")

--- a/src/remage.cc
+++ b/src/remage.cc
@@ -19,11 +19,8 @@
 #include "RMGHardware.hh"
 #include "RMGLog.hh"
 #include "RMGManager.hh"
+#include "RMGTools.hh"
 
-#ifndef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY
-#endif
-#include "fmt/core.h"
 #include "magic_enum/magic_enum.hpp"
 
 namespace CLI {
@@ -56,8 +53,7 @@ int main(int argc, char** argv) {
   std::string output;
   RMGLog::LogLevel loglevel = RMGLog::summary;
 
-  auto log_level_strings = magic_enum::enum_names<RMGLog::LogLevel>();
-  auto log_level_desc = fmt::format("Logging level {}", fmt::join(log_level_strings, "|"));
+  auto log_level_desc = "Logging level " + RMGTools::GetCandidates<RMGLog::LogLevel>('|');
 
   app.add_flag("-q", quiet, "Print only warnings and errors");
   app.add_flag("-v", verbosity, "Increase verbosity");


### PR DESCRIPTION
* We already had `RMGTools` for handling of string/enums, so removing some usages of fmt/magic_enum
* `/RMG/Manager/Include` modifies the vector of macro files while it is being iterated. This is potentially unsafe (it might invalidate the iterator).
   Moreover, I think this command is rather useless: One can just use `/control/execute` instead. The command also did never work in interactive mode.
* The `_RMG_*` constants in the header files where not aligned with the file names anymore (after a lot of renames)
* Some physics commands cann only be used in `G4State_PreInit`; their value is just used once in the physics list setup. Changing it afterwards will not work.