### PR TITLE
Refactor messengers

### DIFF
--- a/include/RMGEventAction.hh
+++ b/include/RMGEventAction.hh
@@ -41,8 +41,6 @@ class RMGEventAction : public G4UserEventAction {
 
   private:
 
-    std::unique_ptr<G4GenericMessenger> fMessenger;
-    void DefineCommands();
     RMGRunAction* fRunAction = nullptr;
 };
 

--- a/include/RMGManager.hh
+++ b/include/RMGManager.hh
@@ -31,8 +31,8 @@
 class G4VUserPhysicsList;
 class RMGHardware;
 class RMGUserAction;
-class RMGManagerMessenger;
 class G4GenericMessenger;
+class G4UIExecutive;
 class RMGManager {
 
   public:
@@ -109,6 +109,8 @@ class RMGManager {
     void SetUpDefaultDetectorConstruction();
     void SetUpDefaultProcessesList();
     void SetUpDefaultUserAction();
+
+    std::unique_ptr<G4UIExecutive> StartInteractiveSession();
 
     std::string fApplicationName;
     int fArgc;

--- a/include/RMGPhysics.hh
+++ b/include/RMGPhysics.hh
@@ -23,7 +23,6 @@
 #include "G4VModularPhysicsList.hh"
 #include "globals.hh"
 
-class RMGProcessesMessenger;
 class RMGPhysics : public G4VModularPhysicsList {
 
   public:

--- a/src/RMGEventAction.cc
+++ b/src/RMGEventAction.cc
@@ -32,10 +32,7 @@
 #include "fmt/chrono.h"
 #include "magic_enum/magic_enum.hpp"
 
-RMGEventAction::RMGEventAction(RMGRunAction* run_action) : fRunAction(run_action) {
-
-  this->DefineCommands();
-}
+RMGEventAction::RMGEventAction(RMGRunAction* run_action) : fRunAction(run_action) {}
 
 void RMGEventAction::BeginOfEventAction(const G4Event* event) {
 
@@ -77,12 +74,6 @@ void RMGEventAction::EndOfEventAction(const G4Event* event) {
   }
 
   // NOTE: G4analysisManager::AddNtupleRow() must be called here for event-oriented output
-}
-
-void RMGEventAction::DefineCommands() {
-
-  fMessenger = std::make_unique<G4GenericMessenger>(this, "/RMG/Output/",
-      "Commands for controlling the event actions");
 }
 
 // vim: tabstop=2 shiftwidth=2 expandtab

--- a/src/RMGHardware.cc
+++ b/src/RMGHardware.cc
@@ -55,7 +55,7 @@ G4VPhysicalVolume* RMGHardware::Construct() {
     fWorld = this->DefineGeometry();
     if (!fWorld)
       RMGLog::Out(RMGLog::fatal, "DefineGeometry() returned nullptr. ",
-          "Did you forget to reimplement the base class method?");
+          "Did you forget to reimplement the base class method, or to specify a GDML file?");
   }
 
   // TODO: build and return world volume?

--- a/src/RMGHardwareMessenger.cc
+++ b/src/RMGHardwareMessenger.cc
@@ -23,7 +23,6 @@
 RMGHardwareMessenger::RMGHardwareMessenger(RMGHardware* hw) : fHardware(hw) {
   fRegisterCmd = new G4UIcommand("/RMG/Geometry/RegisterDetector", this);
   fRegisterCmd->SetGuidance("register a sensitive detector");
-  fRegisterCmd->SetGuidance("[usage] /RMG/Geometry/RegisterDetector T PV ID [C]");
 
   auto p_type = new G4UIparameter("type", 's', false);
   p_type->SetParameterCandidates(RMGTools::GetCandidates<RMGHardware::DetectorType>().c_str());

--- a/src/RMGPhysics.cc
+++ b/src/RMGPhysics.cc
@@ -366,19 +366,23 @@ void RMGPhysics::DefineCommands() {
       .SetCandidates(RMGTools::GetCandidates<RMGPhysics::LowEnergyEMOption>())
       .SetStates(G4State_PreInit);
 
+  // TODO: upstream bug with bools in G4GenericMessenger (only numeric values work).
   fMessenger->DeclareMethod("EnableGammaAngularCorrelation", &RMGPhysics::SetUseGammaAngCorr)
-      .SetGuidance("")
-      .SetStates(G4State_PreInit, G4State_Idle);
+      .SetGuidance("Set correlated gamma emission flag")
+      .SetCandidates("0 1")
+      .SetStates(G4State_PreInit);
 
   fMessenger->DeclareMethod("GammaTwoJMAX", &RMGPhysics::SetGammaTwoJMAX)
-      .SetGuidance("")
+      .SetGuidance("Set max 2J for sampling of angular correlations")
       .SetParameterName("x", false)
       .SetRange("x > 0")
-      .SetStates(G4State_PreInit, G4State_Idle);
+      .SetStates(G4State_PreInit);
 
+  // TODO: upstream bug with bools in G4GenericMessenger (only numeric values work).
   fMessenger->DeclareMethod("StoreICLevelData", &RMGPhysics::SetStoreICLevelData)
-      .SetGuidance("")
-      .SetStates(G4State_PreInit, G4State_Idle);
+      .SetGuidance("Store e- internal conversion data")
+      .SetCandidates("0 1")
+      .SetStates(G4State_PreInit);
 }
 
 // vim: shiftwidth=2 tabstop=2 expandtab


### PR DESCRIPTION
* Refactor out a helper function to initialize an interactive session. This allows to do a late intitialization of an interactive session. Before that change, using the command to use an interactive session just segfaulted with a null ptr deref.
* There is an upstream bug with bools in `G4GenericMessenger::DeclareMethod()`, only numeric values work, other values like `true` will be silently ignored.
   I have added a temporary fix to the affected physics commands, and switched `/RMG/Manager/Interactive` to `DeclareProperty` (which is not affected by the bug)
* Some commands in `RMGPhysics` have been restricted to the PreInit state.
   see `G4DeexPrecoParameters::IsLocked()` which just _silently_ discards any changes to the `G4DeexPrecoParameters` if the state is not PreInit.
* Some guidance and parameter name changes.