### PR TITLE
physics: add option to disable long-lived daughter nuclei in decay chains

### DIFF
--- a/include/RMGSteppingAction.hh
+++ b/include/RMGSteppingAction.hh
@@ -16,6 +16,7 @@
 #ifndef _RMG_STEPPING_ACTION_HH_
 #define _RMG_STEPPING_ACTION_HH_
 
+#include "G4GenericMessenger.hh"
 #include "G4UserSteppingAction.hh"
 
 class G4Step;
@@ -34,9 +35,15 @@ class RMGSteppingAction : public G4UserSteppingAction {
 
     void UserSteppingAction(const G4Step*) override;
 
+    void SetDaughterKillLifetime(double max_lifetime);
+
   private:
 
     RMGEventAction* fEventAction = nullptr;
+    double fDaughterKillLifetime = -1;
+
+    std::unique_ptr<G4GenericMessenger> fMessenger;
+    void DefineCommands();
 };
 
 #endif


### PR DESCRIPTION
this code is somewhat inspired by MaGe, but reworked and modernized. The functionality can be enabled and configured via a macro command

### Alternatives (we should document this somewhere...)
```
/process/had/rdm/thresholdForVeryLongDecayTime <threshold> ms
```
this has two problems:
1. the time limit is applied to the sampled global time of the decay of an unstable nucleus. This is not deterministic (i.e. it is  dependent on the random seed), and also not really helpful to limit decays to specific isotopes
2. This also applies to primaries created with GPS, so one cannot simulate any decay to create secondaries.


```
/process/had/rdm/nucleusLimits <AMin> <AMax> <ZMin> <ZMax>
```
This method works and is reliable/deterministic, but you have to define the limits carefully, especially if you have multiple possible primary decays.

fixes #39