### PR TITLE
Fix CI tests not failing, fix some other minor bugs

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,4 +25,4 @@ CheckOptions:
   value: true
 
 FormatStyle: file
-HeaderFilterRegex: 'include/.*.hh'
+HeaderFilterRegex: 'include/.*\.(hh|icc)'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,11 +44,11 @@ jobs:
       if: ${{ matrix.container_version != 'slim' }}
       run: |
         cd build
-        ctest --output-on-failure
+        ctest --output-on-failure --label-exclude 'vis'
     - name: Run minimal test suite
       if: ${{ matrix.container_version == 'slim' }}
       run: |
         cd build
-        ctest --output-on-failure --label-exclude extra
+        ctest --output-on-failure --label-exclude 'extra|vis'
 
 # vim: expandtab tabstop=2 shiftwidth=2

--- a/include/RMGExceptionHandler.hh
+++ b/include/RMGExceptionHandler.hh
@@ -1,0 +1,57 @@
+// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option) any
+// later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef _RMG_EXCEPTION_HANDLER_HH_
+#define _RMG_EXCEPTION_HANDLER_HH_
+
+#include <memory>
+#include <vector>
+
+#include "globals.hh"
+
+#include "G4ExceptionHandler.hh"
+
+#include "RMGLog.hh"
+
+class G4VUserPhysicsList;
+class RMGHardware;
+class RMGUserAction;
+class G4GenericMessenger;
+class G4UIExecutive;
+class RMGExceptionHandler : public G4ExceptionHandler {
+
+  public:
+
+    RMGExceptionHandler() = default;
+    ~RMGExceptionHandler() = default;
+
+    RMGExceptionHandler(const RMGExceptionHandler&) = delete;
+    RMGExceptionHandler& operator=(const RMGExceptionHandler&) = delete;
+
+    bool Notify(const char* originOfException, const char* exceptionCode,
+        G4ExceptionSeverity severity, const char* description) override;
+
+    [[nodiscard]] inline bool HadWarning() const { return fHadWarning; }
+    [[nodiscard]] inline bool HadError() const { return fHadError; }
+
+  private:
+
+    bool fHadWarning = false;
+    bool fHadError = false;
+};
+
+#endif
+
+// vim: tabstop=2 shiftwidth=2 expandtab

--- a/include/RMGLog.hh
+++ b/include/RMGLog.hh
@@ -140,6 +140,9 @@ class RMGLog {
     template<RMGLog::Ansi color, typename T>
     static std::string Colorize(const T& msg, std::ostream& os, bool bold = false);
 
+    inline static bool HadWarning() { return fHadWarning; }
+    inline static bool HadError() { return fHadError; }
+
     /** @} */
 
   private:
@@ -164,6 +167,14 @@ class RMGLog {
     /**
      * Specifies whether there were output printouts already */
     static bool fFirstOutputDone;
+
+    /**
+     * Specifies whether there was any warning logged yet */
+    static bool fHadWarning;
+
+    /**
+     * Specifies whether there was any error logged yet */
+    static bool fHadError;
 
     /**
      * Include a prefix before each message? */

--- a/include/RMGLog.icc
+++ b/include/RMGLog.icc
@@ -19,6 +19,12 @@
 
 template <typename T>
 inline void RMGLog::Print(RMGLog::LogLevel loglevel, const T& msg, bool prefixed, bool do_flush) {
+  if (loglevel >= RMGLog::error) {
+    fHadError = true;
+  } else if (loglevel == RMGLog::warning) {
+    fHadWarning = true;
+  }
+
   // write message to screen
   if (loglevel >= RMGLog::fMinimumLogLevel) {
     std::ostream& strm = loglevel > RMGLog::LogLevel::warning ? G4cout : G4cerr;
@@ -70,7 +76,7 @@ inline void RMGLog::OutFormat(RMGLog::LogLevel loglevel, const std::string& fmt,
         RMGLog::Out(loglevel, fmt::format(fmt, args...));
     }
     catch (fmt::v8::format_error& e) {
-        RMGLog::Out(RMGLog::error, "fmt library exception caugth: ", e.what());
+        RMGLog::Out(RMGLog::error, "fmt library exception caught: ", e.what());
     }
 }
 

--- a/include/RMGManager.hh
+++ b/include/RMGManager.hh
@@ -26,6 +26,7 @@
 #include "G4Threading.hh"
 #include "G4VisManager.hh"
 
+#include "RMGExceptionHandler.hh"
 #include "RMGLog.hh"
 
 class G4VUserPhysicsList;
@@ -102,6 +103,13 @@ class RMGManager {
     }
     inline int GetNtupleID(int det_uid) { return fNtupleIDs[det_uid]; }
 
+    [[nodiscard]] inline bool HadWarning() const {
+      return fExceptionHandler->HadWarning() || RMGLog::HadWarning();
+    }
+    [[nodiscard]] inline bool HadError() const {
+      return fExceptionHandler->HadError() || RMGLog::HadError();
+    }
+
   private:
 
     void SetUpDefaultG4RunManager(G4RunManagerType type = G4RunManagerType::Default);
@@ -134,6 +142,7 @@ class RMGManager {
     G4VUserPhysicsList* fPhysicsList = nullptr;
     RMGHardware* fDetectorConstruction = nullptr;
     RMGUserAction* fUserAction = nullptr;
+    RMGExceptionHandler* fExceptionHandler = nullptr;
 
     // messenger stuff
     std::unique_ptr<G4GenericMessenger> fMessenger;

--- a/include/RMGTools.icc
+++ b/include/RMGTools.icc
@@ -36,7 +36,7 @@ namespace RMGTools {
     template <typename T>
     std::string GetCandidates(const char delim=' ') {
         auto v = magic_enum::enum_names<T>();
-        std::string cand = "";
+        std::string cand;
         for (const auto& s : v) {
             auto name = s[0] == 'k' ? s.substr(1, std::string::npos) : s;
             cand += std::string(name) + delim;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(_root ${PROJECT_SOURCE_DIR})
 
 set(PROJECT_PUBLIC_HEADERS
+    ${_root}/include/RMGExceptionHandler.hh
     ${_root}/include/RMGEventAction.hh
     ${_root}/include/RMGGeneratorCosmicMuons.hh
     ${_root}/include/RMGGeneratorG4Gun.hh
@@ -32,6 +33,7 @@ set(PROJECT_PUBLIC_HEADERS
     ${_root}/include/RMGVVertexGenerator.hh)
 
 set(PROJECT_SOURCES
+    ${_root}/src/RMGExceptionHandler.cc
     ${_root}/src/RMGHardware.cc
     ${_root}/src/RMGHardwareMessenger.cc
     ${_root}/src/RMGEventAction.cc

--- a/src/RMGExceptionHandler.cc
+++ b/src/RMGExceptionHandler.cc
@@ -1,0 +1,32 @@
+// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option) any
+// later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "RMGExceptionHandler.hh"
+
+#include "G4ExceptionHandler.hh"
+
+bool RMGExceptionHandler::Notify(const char* originOfException, const char* exceptionCode,
+    G4ExceptionSeverity severity, const char* description) {
+
+  if (severity == JustWarning) {
+    fHadWarning = true;
+  } else {
+    fHadError = true;
+  }
+
+  return G4ExceptionHandler::Notify(originOfException, exceptionCode, severity, description);
+}
+
+// vim: tabstop=2 shiftwidth=2 expandtab

--- a/src/RMGLog.cc
+++ b/src/RMGLog.cc
@@ -31,6 +31,8 @@
 RMGLog::LogLevel RMGLog::fMinimumLogLevel = RMGLog::summary;
 
 bool RMGLog::fFirstOutputDone = false;
+bool RMGLog::fHadWarning = false;
+bool RMGLog::fHadError = false;
 
 bool RMGLog::fUsePrefix = true;
 

--- a/src/RMGManager.cc
+++ b/src/RMGManager.cc
@@ -27,6 +27,7 @@
 #endif
 #include "G4Backtrace.hh"
 #include "G4GenericMessenger.hh"
+#include "G4StateManager.hh"
 #include "G4UIExecutive.hh"
 #include "G4UImanager.hh"
 #include "G4VUserPhysicsList.hh"
@@ -35,6 +36,7 @@
 #include "Randomize.hh"
 
 #include "RMGConfig.hh"
+#include "RMGExceptionHandler.hh"
 #include "RMGHardware.hh"
 #include "RMGPhysics.hh"
 #include "RMGTools.hh"
@@ -156,6 +158,9 @@ void RMGManager::SetUpDefaultG4RunManager(G4RunManagerType type) {
   // save underlying buffer and set null (only standard output)
   std::streambuf* orig_buf = std::cout.rdbuf();
   std::cout.rdbuf(nullptr);
+
+  fExceptionHandler = new RMGExceptionHandler();
+  G4StateManager::GetStateManager()->SetExceptionHandler(fExceptionHandler);
 
   fG4RunManager = std::unique_ptr<G4RunManager>(G4RunManagerFactory::CreateRunManager(type));
   fG4RunManager->SetVerboseLevel(0);

--- a/src/RMGRunAction.cc
+++ b/src/RMGRunAction.cc
@@ -107,8 +107,12 @@ void RMGRunAction::BeginOfRunAction(const G4Run*) {
     if (this->IsMaster())
       RMGLog::Out(RMGLog::summary, "Opening output file: ", manager->GetOutputFileName());
     ana_man->OpenFile(manager->GetOutputFileName());
-  } else {
-    if (this->IsMaster()) RMGLog::Out(RMGLog::warning, "Object persistency disabled");
+  } else if (this->IsMaster()) {
+    // Warn user if persistency is disabled if there are detectors defined.
+    auto level = manager->GetDetectorConstruction()->GetActiveDetectorList().empty()
+                     ? RMGLog::summary
+                     : RMGLog::warning;
+    RMGLog::Out(level, "Object persistency disabled");
   }
 
   if (fRMGMasterGenerator) {
@@ -174,7 +178,8 @@ void RMGRunAction::EndOfRunAction(const G4Run*) {
         "Stats: average event processing time was {:.5g} seconds/event = {:.5g} events/second",
         total_sec_hres / n_ev, n_ev / total_sec_hres);
 
-    if (n_ev < 100) RMGLog::Out(RMGLog::warning, "Event processing time might be inaccurate");
+    if (n_ev < 100)
+      RMGLog::Out(RMGLog::summary, "Stats: Event processing time might be inaccurate");
   }
 
   if (fRMGMasterGenerator) {

--- a/src/RMGRunAction.cc
+++ b/src/RMGRunAction.cc
@@ -151,9 +151,17 @@ void RMGRunAction::EndOfRunAction(const G4Run*) {
   if (this->IsMaster()) {
     auto time_now = std::chrono::system_clock::now();
 
+    int n_ev = fRMGRun->GetNumberOfEvent();
+    int n_ev_requested = fRMGRun->GetNumberOfEventToBeProcessed();
+
     RMGLog::OutFormat(RMGLog::summary,
         "Run nr. {:d} completed. {:d} events simulated. Current local time is {:%d-%m-%Y %H:%M:%S}",
-        fRMGRun->GetRunID(), fRMGRun->GetNumberOfEventToBeProcessed(), fmt::localtime(time_now));
+        fRMGRun->GetRunID(), n_ev, fmt::localtime(time_now));
+    if (n_ev != n_ev_requested) {
+      RMGLog::OutFormat(RMGLog::warning,
+          "Run nr. {:d} only simulated {:d} events, out of {:d} events requested!",
+          fRMGRun->GetRunID(), n_ev, n_ev_requested);
+    }
 
     auto start_time = fRMGRun->GetStartTime();
     auto tot_elapsed_s =
@@ -171,9 +179,9 @@ void RMGRunAction::EndOfRunAction(const G4Run*) {
         "Stats: run time was {:d} days, {:d} hours, {:d} minutes and {:d} seconds", elapsed_d,
         elapsed_h, elapsed_m, elapsed_s);
 
-    auto total_sec_hres = std::chrono::duration<double>(time_now - fRMGRun->GetStartTime()).count();
+    auto total_sec_hres =
+        (double)std::chrono::duration<double>(time_now - fRMGRun->GetStartTime()).count();
 
-    double n_ev = fRMGRun->GetNumberOfEvent();
     RMGLog::OutFormat(RMGLog::summary,
         "Stats: average event processing time was {:.5g} seconds/event = {:.5g} events/second",
         total_sec_hres / n_ev, n_ev / total_sec_hres);

--- a/src/RMGVertexConfinement.cc
+++ b/src/RMGVertexConfinement.cc
@@ -553,7 +553,7 @@ RMGVertexConfinement::GenericGeometricalSolidData& RMGVertexConfinement::SafeBac
     RMGLog::Out(RMGLog::fatal,
         "Solids for vertex confinement have already been initialized, no change possible!");
   }
-  if (!solid_type.has_value() && fGeomVolumeData.back().solid_type != solid_type) {
+  if (solid_type.has_value() && fGeomVolumeData.back().solid_type != solid_type) {
     RMGLog::OutFormat(RMGLog::fatal, "Trying to modify non-{0} as {0}", solid_type.value());
   }
   return fGeomVolumeData.back();

--- a/src/RMGVertexConfinement.cc
+++ b/src/RMGVertexConfinement.cc
@@ -566,7 +566,8 @@ void RMGVertexConfinement::BeginOfRunAction(const G4Run* run) {
 }
 
 void RMGVertexConfinement::EndOfRunAction(const G4Run* run) {
-  auto n_ev = run->GetNumberOfEventToBeProcessed();
+  auto n_ev = run->GetNumberOfEvent();
+  if (n_ev == 0) return;
   auto avg_iter = fTrials * 1. / n_ev;
   RMGLog::OutFormat(RMGLog::summary, "Stats: on average, {:.1f} iterations were needed to sample a valid vertex ({:.1f}% efficiency)",
       avg_iter, 100 / avg_iter);

--- a/src/remage.cc
+++ b/src/remage.cc
@@ -86,7 +86,8 @@ int main(int argc, char** argv) {
   manager.Initialize();
   manager.Run();
 
-  return 0;
+  if (manager.HadWarning()) return 2;
+  return manager.HadError() ? 1 : 0;
 }
 
 // vim: tabstop=2 shiftwidth=2 expandtab

--- a/tests/basics/CMakeLists.txt
+++ b/tests/basics/CMakeLists.txt
@@ -9,10 +9,11 @@ foreach(_file ${_aux})
   configure_file(${PROJECT_SOURCE_DIR}/${_file} ${PROJECT_BINARY_DIR}/${_file} COPYONLY)
 endforeach()
 
-set(_macros print-volumes.mac vis-co60.mac)
-set(_macros_extra run-2nbb.mac vis-2nbb.mac)
+set(_macros print-volumes.mac)
+set(_macros_extra run-2nbb.mac)
+set(_macros_vis vis-co60.mac vis-2nbb.mac)
 
-foreach(_mac ${_macros} ${_macros_extra})
+foreach(_mac ${_macros} ${_macros_extra} ${_macros_vis})
   add_test(NAME basics/${_mac} COMMAND remage-cli -g gdml/main.gdml -- macros/${_mac})
 endforeach()
 
@@ -23,3 +24,6 @@ endforeach()
 
 list(TRANSFORM _macros_extra PREPEND "basics/")
 set_tests_properties(${_macros_extra} PROPERTIES LABELS extra)
+
+list(TRANSFORM _macros_vis PREPEND "basics/")
+set_tests_properties(${_macros_vis} PROPERTIES LABELS vis)

--- a/tests/confinement/CMakeLists.txt
+++ b/tests/confinement/CMakeLists.txt
@@ -13,8 +13,14 @@ set(_macros complex-volume.mac geometrical.mac native-surface.mac geometrical-an
             geometrical-or-physical.mac native-volume.mac)
 
 foreach(_mac ${_macros})
-  add_test(NAME confinement/${_mac} COMMAND remage-cli -g gdml/geometry.gdml -- macros/${_mac})
-  add_test(NAME confinement-mt/${_mac} COMMAND remage-cli -g gdml/geometry.gdml -t 2
-                                               macros/${_mac})
+  add_test(NAME confinement/${_mac} COMMAND remage-cli -g gdml/geometry.gdml -o test-out.root --
+                                            macros/${_mac})
+
+  add_test(NAME confinement-mt/${_mac} COMMAND remage-cli -g gdml/geometry.gdml -t 2 -o
+                                               test-out.root -- macros/${_mac})
   set_tests_properties(confinement-mt/${_mac} PROPERTIES LABELS mt)
+
+  add_test(NAME confinement-vis/${_mac} COMMAND remage-cli -g gdml/geometry.gdml -o test-out.root
+                                                -- macros/vis.mac macros/${_mac})
+  set_tests_properties(confinement-vis/${_mac} PROPERTIES LABELS vis)
 endforeach()

--- a/tests/confinement/macros/complex-volume.mac
+++ b/tests/confinement/macros/complex-volume.mac
@@ -1,4 +1,4 @@
-/control/execute macros/vis.mac
+/control/execute macros/init.mac
 
 /RMG/Generator/Confine Volume
 

--- a/tests/confinement/macros/geometrical-and-physical.mac
+++ b/tests/confinement/macros/geometrical-and-physical.mac
@@ -1,4 +1,4 @@
-/control/execute macros/vis.mac
+/control/execute macros/init.mac
 
 /RMG/Generator/Confine Volume
 

--- a/tests/confinement/macros/geometrical-or-physical.mac
+++ b/tests/confinement/macros/geometrical-or-physical.mac
@@ -1,4 +1,4 @@
-/control/execute macros/vis.mac
+/control/execute macros/init.mac
 
 /RMG/Generator/Confine Volume
 

--- a/tests/confinement/macros/geometrical.mac
+++ b/tests/confinement/macros/geometrical.mac
@@ -1,4 +1,4 @@
-/control/execute macros/vis.mac
+/control/execute macros/init.mac
 
 /RMG/Generator/Confine Volume
 

--- a/tests/confinement/macros/init.mac
+++ b/tests/confinement/macros/init.mac
@@ -1,0 +1,3 @@
+/run/initialize
+
+/RMG/Manager/Logging/LogLevel debug

--- a/tests/confinement/macros/native-surface.mac
+++ b/tests/confinement/macros/native-surface.mac
@@ -1,4 +1,4 @@
-/control/execute macros/vis.mac
+/control/execute macros/init.mac
 
 /RMG/Generator/Confine Volume
 /RMG/Generator/Confinement/SampleOnSurface true

--- a/tests/confinement/macros/native-volume.mac
+++ b/tests/confinement/macros/native-volume.mac
@@ -1,4 +1,4 @@
-/control/execute macros/vis.mac
+/control/execute macros/init.mac
 
 /RMG/Generator/Confine Volume
 /RMG/Generator/Confinement/Physical/AddVolume Box

--- a/tests/confinement/macros/vis.mac
+++ b/tests/confinement/macros/vis.mac
@@ -19,5 +19,8 @@
 /vis/modeling/trajectories/drawByCharge-0/default/setDrawStepPts true
 /vis/modeling/trajectories/drawByCharge-0/default/setStepPtsSize 2
 
+/vis/geometry/set/forceSolid
+/vis/geometry/set/colour all 10 1 1 1 0.3
+
 /vis/scene/add/hits
 /vis/scene/endOfEventAction accumulate


### PR DESCRIPTION
* Fix bug introduced in PR #73
* Introduce a new class `RMGExceptionHandler` to catch genat4 warning/errors, and to adjust the exist code accordingly
* For this to give us any reasonable results, I demoted some warnings to summary messages. Now you can run the tests without any warnings
    * It is not really a reason to warn if the run stats are inaccurate because of low event numbers
    * Also do not warn if no persistency is enabled, and no detectors are registered.
* Do not test anything with visualization in CI, this will not work, see #76
* This also fixes some wrong stats on case of aborted runs (and adds a warning for that)

fixes #76 