### PR TITLE
add option to discard event with energy cuts in germanium

### DIFF
--- a/include/RMGGermaniumDetector.hh
+++ b/include/RMGGermaniumDetector.hh
@@ -77,9 +77,6 @@ class RMGGermaniumDetector : public G4VSensitiveDetector {
   private:
 
     RMGGermaniumDetectorHitsCollection* fHitsCollection = nullptr;
-
-    std::unique_ptr<G4GenericMessenger> fMessenger = nullptr;
-    void DefineCommands();
 };
 
 extern G4ThreadLocal G4Allocator<RMGGermaniumDetectorHit>* RMGGermaniumDetectorHitAllocator;

--- a/include/RMGGermaniumOutputScheme.hh
+++ b/include/RMGGermaniumOutputScheme.hh
@@ -39,6 +39,10 @@ class RMGGermaniumOutputScheme : public RMGVOutputScheme {
     inline void SetEdepCutHigh(double threshold) { fEdepCutHigh = threshold; }
     inline void AddEdepCutDetector(int det_uid) { fEdepCutDetectors.insert(det_uid); }
 
+    [[nodiscard]] inline bool GetDiscardPhotonsIfNoGermaniumEdep() const {
+      return fDiscardPhotonsIfNoGermaniumEdep;
+    }
+
   private:
 
     RMGGermaniumDetectorHitsCollection* GetHitColl(const G4Event*);
@@ -49,6 +53,8 @@ class RMGGermaniumOutputScheme : public RMGVOutputScheme {
     double fEdepCutLow = -1;
     double fEdepCutHigh = -1;
     std::set<int> fEdepCutDetectors;
+
+    bool fDiscardPhotonsIfNoGermaniumEdep = false;
 };
 
 #endif

--- a/include/RMGGermaniumOutputScheme.hh
+++ b/include/RMGGermaniumOutputScheme.hh
@@ -16,6 +16,7 @@
 #ifndef _RMG_GERMANIUM_OUTPUT_SCHEME_HH_
 #define _RMG_GERMANIUM_OUTPUT_SCHEME_HH_
 
+#include <optional>
 #include <set>
 
 #include "G4AnalysisManager.hh"
@@ -34,14 +35,12 @@ class RMGGermaniumOutputScheme : public RMGVOutputScheme {
     void AssignOutputNames(G4AnalysisManager* ana_man) override;
     void StoreEvent(const G4Event*) override;
     bool ShouldDiscardEvent(const G4Event*) override;
+    std::optional<bool> StackingActionNewStage(int) override;
+    std::optional<G4ClassificationOfNewTrack> StackingActionClassify(const G4Track*, int) override;
 
     inline void SetEdepCutLow(double threshold) { fEdepCutLow = threshold; }
     inline void SetEdepCutHigh(double threshold) { fEdepCutHigh = threshold; }
     inline void AddEdepCutDetector(int det_uid) { fEdepCutDetectors.insert(det_uid); }
-
-    [[nodiscard]] inline bool GetDiscardPhotonsIfNoGermaniumEdep() const {
-      return fDiscardPhotonsIfNoGermaniumEdep;
-    }
 
   private:
 

--- a/include/RMGGermaniumOutputScheme.hh
+++ b/include/RMGGermaniumOutputScheme.hh
@@ -16,6 +16,12 @@
 #ifndef _RMG_GERMANIUM_OUTPUT_SCHEME_HH_
 #define _RMG_GERMANIUM_OUTPUT_SCHEME_HH_
 
+#include <set>
+
+#include "G4AnalysisManager.hh"
+#include "G4GenericMessenger.hh"
+
+#include "RMGGermaniumDetector.hh"
 #include "RMGVOutputScheme.hh"
 
 class G4Event;
@@ -23,10 +29,26 @@ class RMGGermaniumOutputScheme : public RMGVOutputScheme {
 
   public:
 
-    inline RMGGermaniumOutputScheme(G4AnalysisManager* ana_man) : RMGVOutputScheme(ana_man) {}
+    RMGGermaniumOutputScheme();
 
     void AssignOutputNames(G4AnalysisManager* ana_man) override;
-    void EndOfEventAction(const G4Event*) override;
+    void StoreEvent(const G4Event*) override;
+    bool ShouldDiscardEvent(const G4Event*) override;
+
+    inline void SetEdepCutLow(double threshold) { fEdepCutLow = threshold; }
+    inline void SetEdepCutHigh(double threshold) { fEdepCutHigh = threshold; }
+    inline void AddEdepCutDetector(int det_uid) { fEdepCutDetectors.insert(det_uid); }
+
+  private:
+
+    RMGGermaniumDetectorHitsCollection* GetHitColl(const G4Event*);
+
+    std::unique_ptr<G4GenericMessenger> fMessenger;
+    void DefineCommands();
+
+    double fEdepCutLow = -1;
+    double fEdepCutHigh = -1;
+    std::set<int> fEdepCutDetectors;
 };
 
 #endif

--- a/include/RMGHardware.hh
+++ b/include/RMGHardware.hh
@@ -28,6 +28,7 @@
 
 #include "RMGHardwareMessenger.hh"
 #include "RMGNavigationTools.hh"
+#include "RMGVOutputScheme.hh"
 
 class G4VPhysicalVolume;
 class RMGHardware : public G4VUserDetectorConstruction {
@@ -63,6 +64,7 @@ class RMGHardware : public G4VUserDetectorConstruction {
       return fDetectorMetadata.at(det);
     }
     inline const auto& GetActiveDetectorList() { return fActiveDetectors; }
+    inline auto GetActiveOutputScheme(DetectorType type) { return fActiveOutputSchemes.at(type); }
 
     inline void IncludeGDMLFile(std::string filename) { fGDMLFiles.emplace_back(filename); }
     inline virtual G4VPhysicalVolume* DefineGeometry() { return nullptr; }
@@ -84,6 +86,7 @@ class RMGHardware : public G4VUserDetectorConstruction {
     // one element for each sensitive detector physical volume
     std::map<std::pair<std::string, int>, DetectorMetadata> fDetectorMetadata;
     std::set<DetectorType> fActiveDetectors;
+    std::map<DetectorType, std::shared_ptr<RMGVOutputScheme>> fActiveOutputSchemes;
     bool fActiveDetectorsInitialized = false;
 
     std::unique_ptr<G4GenericMessenger> fMessenger;

--- a/include/RMGOpticalDetector.hh
+++ b/include/RMGOpticalDetector.hh
@@ -76,9 +76,6 @@ class RMGOpticalDetector : public G4VSensitiveDetector {
   private:
 
     RMGOpticalDetectorHitsCollection* fHitsCollection = nullptr;
-
-    std::unique_ptr<G4GenericMessenger> fMessenger = nullptr;
-    void DefineCommands();
 };
 
 extern G4ThreadLocal G4Allocator<RMGOpticalDetectorHit>* RMGOpticalDetectorHitAllocator;

--- a/include/RMGOpticalOutputScheme.hh
+++ b/include/RMGOpticalOutputScheme.hh
@@ -18,6 +18,9 @@
 
 #include <vector>
 
+#include "G4AnalysisManager.hh"
+#include "G4GenericMessenger.hh"
+
 #include "RMGVOutputScheme.hh"
 
 class G4Event;
@@ -25,10 +28,15 @@ class RMGOpticalOutputScheme : public RMGVOutputScheme {
 
   public:
 
-    inline RMGOpticalOutputScheme(G4AnalysisManager* ana_man) : RMGVOutputScheme(ana_man) {}
+    RMGOpticalOutputScheme();
 
     void AssignOutputNames(G4AnalysisManager* ana_man) override;
-    void EndOfEventAction(const G4Event*) override;
+    void StoreEvent(const G4Event*) override;
+
+  private:
+
+    std::unique_ptr<G4GenericMessenger> fMessenger;
+    void DefineCommands();
 };
 
 #endif

--- a/include/RMGRunAction.hh
+++ b/include/RMGRunAction.hh
@@ -54,7 +54,7 @@ class RMGRunAction : public G4UserRunAction {
       return fOutputDataFields.at(d_type);
     }
     inline void ClearOutputDataFields() {
-      for (auto& el : fOutputDataFields) el.second->clear();
+      for (auto& el : fOutputDataFields) el.second->ClearBeforeEvent();
     }
 
   private:
@@ -66,7 +66,7 @@ class RMGRunAction : public G4UserRunAction {
 
     int fCurrentPrintModulo = -1;
 
-    std::map<RMGHardware::DetectorType, std::unique_ptr<RMGVOutputScheme>> fOutputDataFields;
+    std::map<RMGHardware::DetectorType, std::shared_ptr<RMGVOutputScheme>> fOutputDataFields;
 };
 
 #endif

--- a/include/RMGRunAction.hh
+++ b/include/RMGRunAction.hh
@@ -50,8 +50,10 @@ class RMGRunAction : public G4UserRunAction {
 
     [[nodiscard]] inline int GetCurrentRunPrintModulo() const { return fCurrentPrintModulo; }
 
-    inline auto& GetOutputDataFields(RMGHardware::DetectorType d_type) {
-      return fOutputDataFields.at(d_type);
+    inline std::shared_ptr<RMGVOutputScheme> GetOutputDataFields(RMGHardware::DetectorType d_type) {
+      auto it = fOutputDataFields.find(d_type);
+      if (it != fOutputDataFields.end()) return (*it).second;
+      return nullptr;
     }
     inline void ClearOutputDataFields() {
       for (auto& el : fOutputDataFields) el.second->ClearBeforeEvent();

--- a/include/RMGRunAction.hh
+++ b/include/RMGRunAction.hh
@@ -52,9 +52,10 @@ class RMGRunAction : public G4UserRunAction {
 
     inline std::shared_ptr<RMGVOutputScheme> GetOutputDataFields(RMGHardware::DetectorType d_type) {
       auto it = fOutputDataFields.find(d_type);
-      if (it != fOutputDataFields.end()) return (*it).second;
+      if (it != fOutputDataFields.end()) return it->second;
       return nullptr;
     }
+    [[nodiscard]] inline const auto& GetAllOutputDataFields() { return fOutputDataFields; }
     inline void ClearOutputDataFields() {
       for (auto& el : fOutputDataFields) el.second->ClearBeforeEvent();
     }

--- a/include/RMGStackingAction.hh
+++ b/include/RMGStackingAction.hh
@@ -19,12 +19,12 @@
 #include "G4UserStackingAction.hh"
 
 class G4Track;
-class RMGEventAction;
+class RMGRunAction;
 class RMGStackingAction : public G4UserStackingAction {
 
   public:
 
-    RMGStackingAction(RMGEventAction*);
+    RMGStackingAction(RMGRunAction*);
     ~RMGStackingAction() = default;
 
     RMGStackingAction(RMGStackingAction const&) = delete;
@@ -38,7 +38,7 @@ class RMGStackingAction : public G4UserStackingAction {
 
   private:
 
-    RMGEventAction* fEventAction = nullptr;
+    RMGRunAction* fRunAction = nullptr;
 };
 
 #endif

--- a/include/RMGStackingAction.hh
+++ b/include/RMGStackingAction.hh
@@ -38,6 +38,7 @@ class RMGStackingAction : public G4UserStackingAction {
 
   private:
 
+    int fStage = 0;
     RMGRunAction* fRunAction = nullptr;
 };
 

--- a/include/RMGVOutputScheme.hh
+++ b/include/RMGVOutputScheme.hh
@@ -16,7 +16,6 @@
 #ifndef _RMG_V_OUTPUT_SCHEME_HH_
 #define _RMG_V_OUTPUT_SCHEME_HH_
 
-#include <map>
 #include <string>
 
 #include "G4AnalysisManager.hh"
@@ -28,10 +27,16 @@ class RMGVOutputScheme {
 
   public:
 
-    inline RMGVOutputScheme(G4AnalysisManager* ana_man) { this->AssignOutputNames(ana_man); }
-    virtual inline void clear() {};
-    virtual inline void AssignOutputNames(G4AnalysisManager*) {};
-    virtual inline void EndOfEventAction(const G4Event*) {};
+    RMGVOutputScheme() = default;
+
+    // initialization.
+    virtual inline void AssignOutputNames(G4AnalysisManager*) {}
+
+    // functions for individual events.
+    virtual inline void ClearBeforeEvent() {}
+    virtual inline bool ShouldDiscardEvent(const G4Event*) { return false; }
+    virtual inline void StoreEvent(const G4Event*) {}
+
     inline std::string GetNtupleName(int det_uid) { return fmt::format("det{:03}", det_uid); }
 };
 

--- a/include/RMGVOutputScheme.hh
+++ b/include/RMGVOutputScheme.hh
@@ -16,9 +16,12 @@
 #ifndef _RMG_V_OUTPUT_SCHEME_HH_
 #define _RMG_V_OUTPUT_SCHEME_HH_
 
+#include <optional>
 #include <string>
 
 #include "G4AnalysisManager.hh"
+#include "G4Track.hh"
+#include "G4UserStackingAction.hh"
 
 #include "fmt/format.h"
 
@@ -36,6 +39,13 @@ class RMGVOutputScheme {
     virtual inline void ClearBeforeEvent() {}
     virtual inline bool ShouldDiscardEvent(const G4Event*) { return false; }
     virtual inline void StoreEvent(const G4Event*) {}
+
+    // hook into RMGStackingAction.
+    virtual inline std::optional<G4ClassificationOfNewTrack> StackingActionClassify(const G4Track*,
+        const int) {
+      return std::nullopt;
+    }
+    virtual inline std::optional<bool> StackingActionNewStage(const int) { return std::nullopt; }
 
     inline std::string GetNtupleName(int det_uid) { return fmt::format("det{:03}", det_uid); }
 };

--- a/src/RMGEventAction.cc
+++ b/src/RMGEventAction.cc
@@ -69,8 +69,14 @@ void RMGEventAction::EndOfEventAction(const G4Event* event) {
   auto det_cons = RMGManager::Instance()->GetDetectorConstruction();
   auto active_dets = det_cons->GetActiveDetectorList();
 
+  // Check if any OutputScheme wants to discard this event.
   for (const auto& d_type : active_dets) {
-    fRunAction->GetOutputDataFields(d_type)->EndOfEventAction(event);
+    bool discard_event = fRunAction->GetOutputDataFields(d_type)->ShouldDiscardEvent(event);
+    if (discard_event) return;
+  }
+
+  for (const auto& d_type : active_dets) {
+    fRunAction->GetOutputDataFields(d_type)->StoreEvent(event);
   }
 
   // NOTE: G4analysisManager::AddNtupleRow() must be called here for event-oriented output

--- a/src/RMGGermaniumDetector.cc
+++ b/src/RMGGermaniumDetector.cc
@@ -42,8 +42,8 @@ G4bool RMGGermaniumDetectorHit::operator==(const RMGGermaniumDetectorHit& right)
 }
 
 void RMGGermaniumDetectorHit::Print() {
-  // TODO: add all fields
   RMGLog::Out(RMGLog::debug, "Detector UID: ", this->detector_uid,
+      " / Particle: ", this->particle_type,
       " / Energy: ", G4BestUnit(this->energy_deposition, "Energy"),
       " / Position: ", this->global_position / CLHEP::m, " m",
       " / Time: ", this->global_time / CLHEP::ns, " ns");
@@ -65,8 +65,6 @@ RMGGermaniumDetector::RMGGermaniumDetector() : G4VSensitiveDetector("Germanium")
   // declare only one hit collection.
   // NOTE: names in the respective output scheme class must match this
   G4VSensitiveDetector::collectionName.insert("Hits");
-
-  this->DefineCommands();
 }
 
 void RMGGermaniumDetector::Initialize(G4HCofThisEvent* hit_coll) {
@@ -133,11 +131,5 @@ bool RMGGermaniumDetector::ProcessHits(G4Step* step, G4TouchableHistory* /*histo
 }
 
 void RMGGermaniumDetector::EndOfEvent(G4HCofThisEvent* /*hit_coll*/) {}
-
-void RMGGermaniumDetector::DefineCommands() {
-
-  fMessenger = std::make_unique<G4GenericMessenger>(this, "/RMG/Detector/Germanium/",
-      "Commands for controlling stuff");
-}
 
 // vim: tabstop=2 shiftwidth=2 expandtab

--- a/src/RMGGermaniumOutputScheme.cc
+++ b/src/RMGGermaniumOutputScheme.cc
@@ -166,6 +166,10 @@ void RMGGermaniumOutputScheme::DefineCommands() {
       .SetGuidance("Take this detector into account for the filtering by /EdepThreshold.")
       .SetParameterName("det_uid", false)
       .SetStates(G4State_Idle);
+
+  fMessenger->DeclareProperty("DiscardPhotonsIfNoGermaniumEdep", fDiscardPhotonsIfNoGermaniumEdep)
+      .SetGuidance("Disable the automatic overlap check after loading a GDML file")
+      .SetStates(G4State_Idle);
 }
 
 // vim: tabstop=2 shiftwidth=2 expandtab

--- a/src/RMGOpticalDetector.cc
+++ b/src/RMGOpticalDetector.cc
@@ -47,8 +47,6 @@ RMGOpticalDetector::RMGOpticalDetector() : G4VSensitiveDetector("Optical") {
   // declare only one hit collection.
   // NOTE: names in the respective output scheme class must match this
   G4VSensitiveDetector::collectionName.insert("Hits");
-
-  this->DefineCommands();
 }
 
 void RMGOpticalDetector::Initialize(G4HCofThisEvent* hit_coll) {
@@ -116,11 +114,5 @@ bool RMGOpticalDetector::ProcessHits(G4Step* step, G4TouchableHistory* /*history
 }
 
 void RMGOpticalDetector::EndOfEvent(G4HCofThisEvent* /*hit_coll*/) {}
-
-void RMGOpticalDetector::DefineCommands() {
-
-  fMessenger = std::make_unique<G4GenericMessenger>(this, "/RMG/Detector/Optical/",
-      "Commands for controlling stuff");
-}
 
 // vim: tabstop=2 shiftwidth=2 expandtab

--- a/src/RMGOpticalOutputScheme.cc
+++ b/src/RMGOpticalOutputScheme.cc
@@ -29,6 +29,8 @@
 
 namespace u = CLHEP;
 
+RMGOpticalOutputScheme::RMGOpticalOutputScheme() { this->DefineCommands(); }
+
 // invoked in RMGRunAction::SetupAnalysisManager()
 void RMGOpticalOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) {
 
@@ -56,7 +58,7 @@ void RMGOpticalOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) {
 }
 
 // invoked in RMGEventAction::EndOfEventAction()
-void RMGOpticalOutputScheme::EndOfEventAction(const G4Event* event) {
+void RMGOpticalOutputScheme::StoreEvent(const G4Event* event) {
   auto sd_man = G4SDManager::GetSDMpointer();
 
   auto hit_coll_id = sd_man->GetCollectionID("Optical/Hits");
@@ -100,5 +102,7 @@ void RMGOpticalOutputScheme::EndOfEventAction(const G4Event* event) {
     }
   }
 }
+
+void RMGOpticalOutputScheme::DefineCommands() {}
 
 // vim: tabstop=2 shiftwidth=2 expandtab

--- a/src/RMGRunAction.cc
+++ b/src/RMGRunAction.cc
@@ -71,24 +71,13 @@ void RMGRunAction::SetupAnalysisManager() {
   auto det_cons = RMGManager::Instance()->GetDetectorConstruction();
   for (const auto& d_type : det_cons->GetActiveDetectorList()) {
 
-    RMGLog::OutFormatDev(RMGLog::debug,
-        "Initializing output scheme for sensitive detector type '{}'", magic_enum::enum_name(d_type));
-
-    // instantiate concrete output scheme class
-    // TODO: allow for library user to register own output scheme
-    switch (d_type) {
-      case RMGHardware::kOptical:
-        fOutputDataFields.emplace(d_type, std::make_unique<RMGOpticalOutputScheme>(ana_man));
-        fOutputDataFields[d_type]->AssignOutputNames(ana_man);
-        break;
-      case RMGHardware::kGermanium:
-        fOutputDataFields.emplace(d_type, std::make_unique<RMGGermaniumOutputScheme>(ana_man));
-        fOutputDataFields[d_type]->AssignOutputNames(ana_man);
-        break;
-      default:
-        RMGLog::OutDev(RMGLog::fatal, "No output scheme sensitive detector type '",
-            magic_enum::enum_name(d_type), "' implemented (implement me)");
+    fOutputDataFields[d_type] = det_cons->GetActiveOutputScheme(d_type);
+    if (!fOutputDataFields[d_type]) {
+      RMGLog::OutDev(RMGLog::fatal, "No output scheme sensitive detector type '",
+          magic_enum::enum_name(d_type), "' implemented (implement me)");
     }
+
+    fOutputDataFields[d_type]->AssignOutputNames(ana_man);
   }
 }
 

--- a/src/RMGStackingAction.cc
+++ b/src/RMGStackingAction.cc
@@ -15,42 +15,57 @@
 
 #include "RMGStackingAction.hh"
 
+#include <optional>
+
 #include "G4EventManager.hh"
-#include "G4OpticalPhoton.hh"
 #include "G4Track.hh"
 
-#include "RMGEventAction.hh"
-#include "RMGGermaniumOutputScheme.hh"
-#include "RMGHardware.hh"
+#include "RMGLog.hh"
 #include "RMGManager.hh"
-#include "RMGOpticalOutputScheme.hh"
 #include "RMGRunAction.hh"
 
 RMGStackingAction::RMGStackingAction(RMGRunAction* runaction) : fRunAction(runaction) {}
 
 G4ClassificationOfNewTrack RMGStackingAction::ClassifyNewTrack(const G4Track* aTrack) {
-  // defer tracking of optical photons.
-  if (aTrack->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition()) return fWaiting;
+  std::optional<G4ClassificationOfNewTrack> new_status = std::nullopt;
+  for (auto& el : fRunAction->GetAllOutputDataFields()) {
+    auto request_status = el.second->StackingActionClassify(aTrack, fStage);
+    if (!request_status.has_value()) continue; // this output scheme does not care.
+
+    if (!new_status.has_value() || new_status.value() == request_status.value()) {
+      new_status = request_status;
+    } else {
+      RMGLog::Out(RMGLog::error,
+          "Conflicting requests for new track classification in RMGStackingAction.");
+    }
+  }
+
+  if (new_status.has_value()) return new_status.value();
   return fUrgent;
 }
 
 void RMGStackingAction::NewStage() {
-  auto ge_output = fRunAction->GetOutputDataFields(RMGHardware::DetectorType::kGermanium);
-  if (ge_output == nullptr) return;
+  // we can have only one result from all output schemes, if we have
+  std::optional<bool> should_do_stage = std::nullopt;
+  for (auto& el : fRunAction->GetAllOutputDataFields()) {
+    auto request_stage = el.second->StackingActionNewStage(fStage);
+    if (!request_stage.has_value()) continue; // this output scheme does not care.
 
-  bool discard_photons =
-      (dynamic_cast<RMGGermaniumOutputScheme&>(*ge_output)).GetDiscardPhotonsIfNoGermaniumEdep();
-  if (!discard_photons) return;
+    if (!should_do_stage.has_value() || should_do_stage.value() == request_stage.value()) {
+      should_do_stage = request_stage;
+    } else {
+      RMGLog::Out(RMGLog::error,
+          "Conflicting requests for new stage termination in RMGStackingAction.");
+    }
+  }
 
-  auto run_man = RMGManager::Instance()->GetG4RunManager();
-  const auto event = run_man->GetCurrentEvent();
-  if (ge_output->ShouldDiscardEvent(event)) {
-    // discard all waiting events, as there was no energy deposition in Germanium.
+  if (should_do_stage.has_value() && !should_do_stage.value()) {
     auto stack_man = G4EventManager::GetEventManager()->GetStackManager();
     stack_man->clear();
   }
+  fStage++;
 }
 
-void RMGStackingAction::PrepareNewEvent() {}
+void RMGStackingAction::PrepareNewEvent() { fStage = 0; }
 
 // vim: tabstop=2 shiftwidth=2 expandtab

--- a/src/RMGUserAction.cc
+++ b/src/RMGUserAction.cc
@@ -42,7 +42,7 @@ void RMGUserAction::Build() const {
   this->SetUserAction(generator_primary);
   this->SetUserAction(event_action);
   this->SetUserAction(run_action);
-  this->SetUserAction(new RMGStackingAction(event_action));
+  this->SetUserAction(new RMGStackingAction(run_action));
   this->SetUserAction(new RMGSteppingAction(event_action));
   this->SetUserAction(new RMGTrackingAction(event_action));
 }


### PR DESCRIPTION
* Remove the unused analysis manager parameter from the output scheme constructors. It is still passed in in every invocation of its functions, as before
* Initialize output schemes at detector construction time. This is necessary to have their commands available to macro files
* Introduce `RMGVOutputScheme::ShouldDiscardEvent()` to be able to discard an event before _any_ output action writes out their data
* Introduce `RMGVOutputScheme::{StackingActionClassify,StackingActionNewStage}()` to be able to hook into the `RMGSTackingAction`


fixes #47 
fixes #41 

---

