### PR TITLE
Use custom overlap check instead of the one from G4GDML

### DIFF
--- a/include/RMGHardware.hh
+++ b/include/RMGHardware.hh
@@ -76,6 +76,7 @@ class RMGHardware : public G4VUserDetectorConstruction {
     /// List of GDML files to load
     std::vector<std::string> fGDMLFiles;
     bool fGDMLDisableOverlapCheck = false;
+    int fGDMLOverlapCheckNumPoints = 3000;
     /// Mapping between physical volume names and maximum (user) step size to apply
     std::map<std::string, double> fPhysVolStepLimits;
 

--- a/tests/basics/CMakeLists.txt
+++ b/tests/basics/CMakeLists.txt
@@ -27,3 +27,10 @@ set_tests_properties(${_macros_extra} PROPERTIES LABELS extra)
 
 list(TRANSFORM _macros_vis PREPEND "basics/")
 set_tests_properties(${_macros_vis} PROPERTIES LABELS vis)
+
+# further specific tests.
+
+# expect two overlaps from this prepared geometry.
+add_test(NAME basics/overlaps.mac COMMAND remage-cli -- macros/overlaps.mac)
+set_tests_properties(basics/overlaps.mac PROPERTIES PASS_REGULAR_EXPRESSION
+                                                    "GeomVol1002.*GeomVol1002")

--- a/tests/basics/gdml/overlaps.gdml
+++ b/tests/basics/gdml/overlaps.gdml
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+	<define/>
+	<materials/>
+	<solids>
+		<box name="World" x="10" y="10" z="10" lunit="m"/>
+		<box name="Box" x="1" y="1" z="1" lunit="m"/>
+	</solids>
+	<structure>
+		<volume name="Box">
+			<materialref ref="G4_Pb"/>
+			<solidref ref="Box"/>
+		</volume>
+		<volume name="World">
+			<materialref ref="G4_Pb"/>
+			<solidref ref="World"/>
+			<physvol name="Box1">
+				<volumeref ref="Box"/>
+				<position name="Box_pos" x="0" y="0" z="0" unit="m"/>
+				<rotation name="Box_rot" x="0" y="0" z="0" unit="rad"/>
+			</physvol>
+			<physvol name="Box2">
+				<volumeref ref="Box"/>
+				<position name="Box_pos" x="0" y="0.5" z="0" unit="m"/>
+				<rotation name="Box_rot" x="0" y="0" z="0" unit="rad"/>
+			</physvol>
+		</volume>
+	</structure>
+	<setup name="Default" version="1.0">
+		<world ref="World"/>
+	</setup>
+</gdml>

--- a/tests/basics/macros/overlaps.mac
+++ b/tests/basics/macros/overlaps.mac
@@ -1,0 +1,2 @@
+/RMG/Geometry/IncludeGDMLFile gdml/overlaps.gdml
+/run/initialize


### PR DESCRIPTION
* call overlap check after reading all GDML files
* reduce verbosity of overlap check; do not show lines of _succeeded_ checks
* also increase the number of points in overlap check, increasing from the default of 1000 to 3000
* this now catches overlaps that were not previously reported...