### PR TITLE
Vertex fixes

### DIFF
--- a/include/RMGGeneratorMUSUNCosmicMuons.hh
+++ b/include/RMGGeneratorMUSUNCosmicMuons.hh
@@ -42,12 +42,11 @@ class RMGGeneratorMUSUNCosmicMuons : public RMGVGenerator {
     RMGGeneratorMUSUNCosmicMuons(RMGGeneratorMUSUNCosmicMuons&&) = delete;
     RMGGeneratorMUSUNCosmicMuons& operator=(RMGGeneratorMUSUNCosmicMuons&&) = delete;
 
-    void GeneratePrimaries(G4Event* event);
-    virtual void SetParticlePosition(G4ThreeVector) override{};
+    void GeneratePrimaries(G4Event* event) override;
+    void SetParticlePosition(G4ThreeVector) override{};
 
-
-    void BeginOfRunAction(const G4Run*);
-    void EndOfRunAction(const G4Run*);
+    void BeginOfRunAction(const G4Run*) override;
+    void EndOfRunAction(const G4Run*) override;
 
   private:
 

--- a/include/RMGRunAction.hh
+++ b/include/RMGRunAction.hh
@@ -48,7 +48,7 @@ class RMGRunAction : public G4UserRunAction {
     void BeginOfRunAction(const G4Run*) override;
     void EndOfRunAction(const G4Run*) override;
 
-    inline int GetCurrentRunPrintModulo() const { return fCurrentPrintModulo; }
+    [[nodiscard]] inline int GetCurrentRunPrintModulo() const { return fCurrentPrintModulo; }
 
     inline auto& GetOutputDataFields(RMGHardware::DetectorType d_type) {
       return fOutputDataFields.at(d_type);

--- a/include/RMGVertexConfinement.hh
+++ b/include/RMGVertexConfinement.hh
@@ -133,6 +133,10 @@ class RMGVertexConfinement : public RMGVVertexGenerator {
   private:
 
     struct VolumeTreeEntry {
+        VolumeTreeEntry() = delete;
+        VolumeTreeEntry(const VolumeTreeEntry&) = default;
+        inline VolumeTreeEntry(G4VPhysicalVolume* pv) { physvol = pv; }
+
         G4VPhysicalVolume* physvol;
 
         G4ThreeVector vol_global_translation; // origin

--- a/include/RMGVertexConfinement.hh
+++ b/include/RMGVertexConfinement.hh
@@ -86,6 +86,7 @@ class RMGVertexConfinement : public RMGVVertexGenerator {
     struct SampleableObject {
 
         SampleableObject() = default;
+        SampleableObject(const SampleableObject&) = default;
         SampleableObject(G4VPhysicalVolume* v, G4RotationMatrix r, G4ThreeVector t, G4VSolid* s,
             bool cc = true);
         // NOTE: G4 volume/solid pointers should be fully owned by G4, avoid trying to delete them
@@ -112,17 +113,12 @@ class RMGVertexConfinement : public RMGVVertexGenerator {
         // emulate std::vector
         [[nodiscard]] size_t size() const { return data.size(); }
         SampleableObject& at(size_t i) { return data.at(i); }
-        void emplace_back(G4VPhysicalVolume* v, const G4RotationMatrix& r, const G4ThreeVector& t,
-            G4VSolid* s, bool cc = true);
-        inline void push_back(const SampleableObject& obj) {
-          this->emplace_back(obj.physical_volume, obj.rotation, obj.translation, obj.sampling_solid,
-              obj.containment_check);
-        }
+        template<typename... Args> void emplace_back(Args&&... args);
         [[nodiscard]] inline bool empty() const { return data.empty(); }
         inline SampleableObject& back() { return data.back(); }
         inline void clear() { data.clear(); }
         inline void insert(SampleableObjectCollection& other) {
-          for (size_t i = 0; i < other.size(); ++i) this->push_back(other.at(i));
+          for (size_t i = 0; i < other.size(); ++i) this->emplace_back(other.at(i));
         }
 
         std::vector<SampleableObject> data;

--- a/src/RMGGeneratorMUSUNCosmicMuons.cc
+++ b/src/RMGGeneratorMUSUNCosmicMuons.cc
@@ -26,8 +26,8 @@ namespace {
   G4Mutex RMGGeneratorMUSUNCosmicMuonsMutex = G4MUTEX_INITIALIZER;
 } // namespace
 
-G4CsvAnalysisReader* RMGGeneratorMUSUNCosmicMuons::fAnalysisReader = 0;
-RMGGeneratorMUSUNCosmicMuons_Data* RMGGeneratorMUSUNCosmicMuons::input_data = 0;
+G4CsvAnalysisReader* RMGGeneratorMUSUNCosmicMuons::fAnalysisReader = nullptr;
+RMGGeneratorMUSUNCosmicMuons_Data* RMGGeneratorMUSUNCosmicMuons::input_data = nullptr;
 
 RMGGeneratorMUSUNCosmicMuons::RMGGeneratorMUSUNCosmicMuons() : RMGVGenerator("MUSUNCosmicMuons") {
   this->DefineCommands();

--- a/src/RMGVertexConfinement.cc
+++ b/src/RMGVertexConfinement.cc
@@ -268,7 +268,7 @@ void RMGVertexConfinement::InitializePhysicalVolumes() {
 
     // queue for paths to the mother volume that still have to be searched.
     std::queue<VolumeTreeEntry> q;
-    q.push({el.physical_volume});
+    q.emplace(el.physical_volume);
 
     for (; !q.empty(); q.pop()) {
       auto v = q.front();
@@ -612,7 +612,7 @@ RMGVertexConfinement::GenericGeometricalSolidData& RMGVertexConfinement::SafeBac
   return fGeomVolumeData.back();
 }
 
-void RMGVertexConfinement::BeginOfRunAction(const G4Run* run) {
+void RMGVertexConfinement::BeginOfRunAction(const G4Run*) {
   // Reset all timers and counters before the next run.
   fTrials = 0;
   fVertexGenerationTime = std::chrono::nanoseconds::zero();

--- a/src/RMGVertexConfinement.cc
+++ b/src/RMGVertexConfinement.cc
@@ -254,10 +254,15 @@ void RMGVertexConfinement::InitializePhysicalVolumes() {
 
       RMGLog::OutDev(RMGLog::debug, "Bounding box coordinates: min = ", lim_min, ", max = ", lim_max);
 
+      // the origin of the local coordinates of the non-sampleable solid is not necessarily at its
+      // barycenter. However, the coordinate origin of a G4Box is always its barycenter.
+      double bb_x = std::max(std::abs(lim_max.getX()), std::abs(lim_min.getX()));
+      double bb_y = std::max(std::abs(lim_max.getY()), std::abs(lim_min.getY()));
+      double bb_z = std::max(std::abs(lim_max.getZ()), std::abs(lim_min.getZ()));
+
       el.sampling_solid =
-          new G4Box(el.physical_volume->GetName() + "/RMGVertexConfinement::fBoundingBox",
-              (lim_max.getX() - lim_min.getX()) / 2, (lim_max.getY() - lim_min.getY()) / 2,
-              (lim_max.getZ() - lim_min.getZ()) / 2);
+          new G4Box(el.physical_volume->GetName() + "/RMGVertexConfinement::fBoundingBox", bb_x,
+              bb_y, bb_z);
     } // sampling_solid and containment_check must hold a valid value at this point
 
 

--- a/src/RMGVertexConfinement.cc
+++ b/src/RMGVertexConfinement.cc
@@ -112,10 +112,10 @@ bool RMGVertexConfinement::SampleableObjectCollection::IsInside(const G4ThreeVec
   return false;
 }
 
-void RMGVertexConfinement::SampleableObjectCollection::emplace_back(G4VPhysicalVolume* v,
-    const G4RotationMatrix& r, const G4ThreeVector& t, G4VSolid* s, bool cc) {
+template<typename... Args>
+void RMGVertexConfinement::SampleableObjectCollection::emplace_back(Args&&... args) {
 
-  this->data.emplace_back(v, r, t, s, cc);
+  this->data.emplace_back(std::forward<Args>(args)...);
 
   const auto& _v = this->data.back().volume;
   const auto& _s = this->data.back().surface;
@@ -339,7 +339,7 @@ void RMGVertexConfinement::InitializePhysicalVolumes() {
 
   // finally add all newly found sampling solids (this os not done directly above as this
   // invalidates old iterators).
-  for (const auto& s : new_obj_from_inspection) { fPhysicalVolumes.push_back(s); }
+  for (const auto& s : new_obj_from_inspection) { fPhysicalVolumes.emplace_back(s); }
 
   RMGLog::Out(RMGLog::detail, "Sampling from ", fPhysicalVolumes.size(), " physical volumes");
 }


### PR DESCRIPTION
fixes #88 

also greatly reduces the number of constructor calls of `SampleableObject`, by the number of events. This should hopefully reduce the number of crashes in MT mode, **but does not fix the root cause**.