### PR TITLE
Vertex output scheme & flatter ntuple structure

### DIFF
--- a/include/RMGGeneratorCosmicMuons.hh
+++ b/include/RMGGeneratorCosmicMuons.hh
@@ -34,7 +34,7 @@ class RMGGeneratorCosmicMuons : public RMGVGenerator {
 
   public:
 
-    enum SkyShape {
+    enum class SkyShape {
       kPlane,
       kSphere
     };
@@ -62,7 +62,7 @@ class RMGGeneratorCosmicMuons : public RMGVGenerator {
     void DefineCommands();
     void SetSkyShape(std::string shape);
 
-    SkyShape fSkyShape = kSphere;
+    SkyShape fSkyShape = SkyShape::kSphere;
     float fSkyPlaneSize = -1;
     float fSkyPlaneHeight = 50;
 

--- a/include/RMGGermaniumOutputScheme.hh
+++ b/include/RMGGermaniumOutputScheme.hh
@@ -42,6 +42,10 @@ class RMGGermaniumOutputScheme : public RMGVOutputScheme {
     inline void SetEdepCutHigh(double threshold) { fEdepCutHigh = threshold; }
     inline void AddEdepCutDetector(int det_uid) { fEdepCutDetectors.insert(det_uid); }
 
+  protected:
+
+    [[nodiscard]] inline std::string GetNtuplenameFlat() const override { return "germanium"; }
+
   private:
 
     RMGGermaniumDetectorHitsCollection* GetHitColl(const G4Event*);

--- a/include/RMGHardware.hh
+++ b/include/RMGHardware.hh
@@ -86,8 +86,8 @@ class RMGHardware : public G4VUserDetectorConstruction {
     // one element for each sensitive detector physical volume
     std::map<std::pair<std::string, int>, DetectorMetadata> fDetectorMetadata;
     std::set<DetectorType> fActiveDetectors;
-    std::vector<std::shared_ptr<RMGVOutputScheme>> fActiveOutputSchemes;
-    bool fActiveDetectorsInitialized = false;
+    static G4ThreadLocal std::vector<std::shared_ptr<RMGVOutputScheme>> fActiveOutputSchemes;
+    static G4ThreadLocal bool fActiveDetectorsInitialized;
 
     std::unique_ptr<G4GenericMessenger> fMessenger;
     std::unique_ptr<RMGHardwareMessenger> fHwMessenger;

--- a/include/RMGHardware.hh
+++ b/include/RMGHardware.hh
@@ -64,7 +64,7 @@ class RMGHardware : public G4VUserDetectorConstruction {
       return fDetectorMetadata.at(det);
     }
     inline const auto& GetActiveDetectorList() { return fActiveDetectors; }
-    inline auto GetActiveOutputScheme(DetectorType type) { return fActiveOutputSchemes.at(type); }
+    [[nodiscard]] inline const auto& GetAllActiveOutputSchemes() { return fActiveOutputSchemes; }
 
     inline void IncludeGDMLFile(std::string filename) { fGDMLFiles.emplace_back(filename); }
     inline virtual G4VPhysicalVolume* DefineGeometry() { return nullptr; }
@@ -86,7 +86,7 @@ class RMGHardware : public G4VUserDetectorConstruction {
     // one element for each sensitive detector physical volume
     std::map<std::pair<std::string, int>, DetectorMetadata> fDetectorMetadata;
     std::set<DetectorType> fActiveDetectors;
-    std::map<DetectorType, std::shared_ptr<RMGVOutputScheme>> fActiveOutputSchemes;
+    std::vector<std::shared_ptr<RMGVOutputScheme>> fActiveOutputSchemes;
     bool fActiveDetectorsInitialized = false;
 
     std::unique_ptr<G4GenericMessenger> fMessenger;

--- a/include/RMGManager.hh
+++ b/include/RMGManager.hh
@@ -60,6 +60,9 @@ class RMGManager {
     }
     [[nodiscard]] inline bool IsPersistencyEnabled() const { return fIsPersistencyEnabled; }
     inline const std::string& GetOutputFileName() { return fOutputFile; }
+    [[nodiscard]] inline bool GetOutputNtuplePerDetector() const {
+      return fOutputNtuplePerDetector;
+    }
 
     // setters
     inline void SetUserInit(G4RunManager* g4_manager) {
@@ -130,6 +133,7 @@ class RMGManager {
     int fPrintModulo = -1;
     int fNThreads = 1;
     std::string fOutputFile = "detector-hits.root";
+    bool fOutputNtuplePerDetector = true;
     // track internal id of detector NTuples
     std::map<int, int> fNtupleIDs;
 

--- a/include/RMGMasterGenerator.hh
+++ b/include/RMGMasterGenerator.hh
@@ -30,13 +30,13 @@ class RMGMasterGenerator : public G4VUserPrimaryGeneratorAction {
 
   public:
 
-    enum Confinement {
+    enum class Confinement {
       kUnConfined,
       kVolume,
       kFromFile,
     };
 
-    enum Generator {
+    enum class Generator {
       kG4gun,
       kGPS,
       kBxDecay0,
@@ -68,10 +68,10 @@ class RMGMasterGenerator : public G4VUserPrimaryGeneratorAction {
 
   private:
 
-    Confinement fConfinement{RMGMasterGenerator::Confinement::kUnConfined};
+    Confinement fConfinement{Confinement::kUnConfined};
     std::unique_ptr<RMGVVertexGenerator> fVertexGeneratorObj;
 
-    Generator fGenerator{RMGMasterGenerator::Generator::kUndefined};
+    Generator fGenerator{Generator::kUndefined};
     std::unique_ptr<RMGVGenerator> fGeneratorObj;
 
     std::unique_ptr<G4GenericMessenger> fMessenger;

--- a/include/RMGOpticalOutputScheme.hh
+++ b/include/RMGOpticalOutputScheme.hh
@@ -33,6 +33,10 @@ class RMGOpticalOutputScheme : public RMGVOutputScheme {
     void AssignOutputNames(G4AnalysisManager* ana_man) override;
     void StoreEvent(const G4Event*) override;
 
+  protected:
+
+    [[nodiscard]] inline std::string GetNtuplenameFlat() const override { return "optical"; }
+
   private:
 
     std::unique_ptr<G4GenericMessenger> fMessenger;

--- a/include/RMGRunAction.hh
+++ b/include/RMGRunAction.hh
@@ -16,8 +16,6 @@
 #ifndef _RMG_RUN_ACTION_HH_
 #define _RMG_RUN_ACTION_HH_
 
-#include <chrono>
-#include <map>
 #include <memory>
 #include <vector>
 
@@ -50,14 +48,9 @@ class RMGRunAction : public G4UserRunAction {
 
     [[nodiscard]] inline int GetCurrentRunPrintModulo() const { return fCurrentPrintModulo; }
 
-    inline std::shared_ptr<RMGVOutputScheme> GetOutputDataFields(RMGHardware::DetectorType d_type) {
-      auto it = fOutputDataFields.find(d_type);
-      if (it != fOutputDataFields.end()) return it->second;
-      return nullptr;
-    }
     [[nodiscard]] inline const auto& GetAllOutputDataFields() { return fOutputDataFields; }
     inline void ClearOutputDataFields() {
-      for (auto& el : fOutputDataFields) el.second->ClearBeforeEvent();
+      for (auto& el : fOutputDataFields) el->ClearBeforeEvent();
     }
 
   private:
@@ -69,7 +62,7 @@ class RMGRunAction : public G4UserRunAction {
 
     int fCurrentPrintModulo = -1;
 
-    std::map<RMGHardware::DetectorType, std::shared_ptr<RMGVOutputScheme>> fOutputDataFields;
+    std::vector<std::shared_ptr<RMGVOutputScheme>> fOutputDataFields;
 };
 
 #endif

--- a/include/RMGVOutputScheme.hh
+++ b/include/RMGVOutputScheme.hh
@@ -48,9 +48,18 @@ class RMGVOutputScheme {
     }
     virtual inline std::optional<bool> StackingActionNewStage(const int) { return std::nullopt; }
 
-    virtual inline std::string GetNtupleName(int det_uid) const {
-      return fmt::format("det{:03}", det_uid);
+    inline void SetNtuplePerDetector(bool ntuple_per_det) { fNtuplePerDetector = ntuple_per_det; }
+
+  protected:
+
+    [[nodiscard]] virtual inline std::string GetNtupleName(int det_uid) const {
+      return fNtuplePerDetector ? fmt::format("det{:03}", det_uid) : GetNtuplenameFlat();
     }
+    [[nodiscard]] virtual inline std::string GetNtuplenameFlat() const {
+      throw new std::logic_error("GetNtuplenameFlat not implemented");
+    }
+
+    bool fNtuplePerDetector = true;
 };
 
 #endif

--- a/include/RMGVOutputScheme.hh
+++ b/include/RMGVOutputScheme.hh
@@ -38,6 +38,7 @@ class RMGVOutputScheme {
     // functions for individual events.
     virtual inline void ClearBeforeEvent() {}
     virtual inline bool ShouldDiscardEvent(const G4Event*) { return false; }
+    [[nodiscard]] virtual inline bool StoreAlways() const { return false; }
     virtual inline void StoreEvent(const G4Event*) {}
 
     // hook into RMGStackingAction.
@@ -47,7 +48,9 @@ class RMGVOutputScheme {
     }
     virtual inline std::optional<bool> StackingActionNewStage(const int) { return std::nullopt; }
 
-    inline std::string GetNtupleName(int det_uid) { return fmt::format("det{:03}", det_uid); }
+    virtual inline std::string GetNtupleName(int det_uid) const {
+      return fmt::format("det{:03}", det_uid);
+    }
 };
 
 #endif

--- a/include/RMGVertexConfinement.hh
+++ b/include/RMGVertexConfinement.hh
@@ -37,7 +37,7 @@ class RMGVertexConfinement : public RMGVVertexGenerator {
 
   public:
 
-    enum GeometricalSolidType {
+    enum class GeometricalSolidType {
       kSphere,
       kCylinder,
       kBox,
@@ -184,29 +184,37 @@ class RMGVertexConfinement : public RMGVVertexGenerator {
     inline void SetGeomVolumeCenterZ(double z) { this->SafeBack().volume_center.setZ(z); }
 
     inline void SetGeomSphereInnerRadius(double r) {
-      this->SafeBack(kSphere).sphere_inner_radius = r;
+      this->SafeBack(GeometricalSolidType::kSphere).sphere_inner_radius = r;
     }
     inline void SetGeomSphereOuterRadius(double r) {
-      this->SafeBack(kSphere).sphere_outer_radius = r;
+      this->SafeBack(GeometricalSolidType::kSphere).sphere_outer_radius = r;
     }
 
     inline void SetGeomCylinderInnerRadius(double r) {
-      this->SafeBack(kCylinder).cylinder_inner_radius = r;
+      this->SafeBack(GeometricalSolidType::kCylinder).cylinder_inner_radius = r;
     }
     inline void SetGeomCylinderOuterRadius(double r) {
-      this->SafeBack(kCylinder).cylinder_outer_radius = r;
+      this->SafeBack(GeometricalSolidType::kCylinder).cylinder_outer_radius = r;
     }
-    inline void SetGeomCylinderHeight(double h) { this->SafeBack(kCylinder).cylinder_height = h; }
+    inline void SetGeomCylinderHeight(double h) {
+      this->SafeBack(GeometricalSolidType::kCylinder).cylinder_height = h;
+    }
     inline void SetGeomCylinderStartingAngle(double a) {
-      this->SafeBack(kCylinder).cylinder_starting_angle = a;
+      this->SafeBack(GeometricalSolidType::kCylinder).cylinder_starting_angle = a;
     }
     inline void SetGeomCylinderSpanningAngle(double a) {
-      this->SafeBack(kCylinder).cylinder_spanning_angle = a;
+      this->SafeBack(GeometricalSolidType::kCylinder).cylinder_spanning_angle = a;
     }
 
-    inline void SetGeomBoxXLength(double x) { this->SafeBack(kBox).box_x_length = x; }
-    inline void SetGeomBoxYLength(double y) { this->SafeBack(kBox).box_y_length = y; }
-    inline void SetGeomBoxZLength(double z) { this->SafeBack(kBox).box_z_length = z; }
+    inline void SetGeomBoxXLength(double x) {
+      this->SafeBack(GeometricalSolidType::kBox).box_x_length = x;
+    }
+    inline void SetGeomBoxYLength(double y) {
+      this->SafeBack(GeometricalSolidType::kBox).box_y_length = y;
+    }
+    inline void SetGeomBoxZLength(double z) {
+      this->SafeBack(GeometricalSolidType::kBox).box_z_length = z;
+    }
 
     void DefineCommands();
 };

--- a/include/RMGVertexOutputScheme.hh
+++ b/include/RMGVertexOutputScheme.hh
@@ -36,7 +36,9 @@ class RMGVertexOutputScheme : public RMGVOutputScheme {
     // always store vertex data, so that results are not skewed if events are discarded.
     [[nodiscard]] inline bool StoreAlways() const override { return true; }
 
-    inline std::string GetNtupleName(int) const override {
+  protected:
+
+    [[nodiscard]] inline std::string GetNtupleName(int) const override {
       throw std::logic_error("vertex output scheme has no detectors");
     }
 

--- a/include/RMGVertexOutputScheme.hh
+++ b/include/RMGVertexOutputScheme.hh
@@ -1,0 +1,54 @@
+// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option) any
+// later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef _RMG_VERTEX_OUTPUT_SCHEME_HH_
+#define _RMG_VERTEX_OUTPUT_SCHEME_HH_
+
+#include <vector>
+
+#include "G4AnalysisManager.hh"
+#include "G4GenericMessenger.hh"
+
+#include "RMGVOutputScheme.hh"
+
+class G4Event;
+class RMGVertexOutputScheme : public RMGVOutputScheme {
+
+  public:
+
+    RMGVertexOutputScheme();
+
+    void AssignOutputNames(G4AnalysisManager* ana_man) override;
+    void StoreEvent(const G4Event*) override;
+
+    // always store vertex data, so that results are not skewed if events are discarded.
+    [[nodiscard]] inline bool StoreAlways() const override { return true; }
+
+    inline std::string GetNtupleName(int) const override {
+      throw std::logic_error("vertex output scheme has no detectors");
+    }
+
+  private:
+
+    std::unique_ptr<G4GenericMessenger> fMessenger;
+    void DefineCommands();
+
+    bool fStorePrimaryParticleInformation = false;
+    bool fSkipPrimaryVertexOutput = false;
+};
+
+#endif
+
+// vim: tabstop=2 shiftwidth=2 expandtab

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,8 @@ set(PROJECT_PUBLIC_HEADERS
     ${_root}/include/RMGVertexFromFile.hh
     ${_root}/include/RMGVGenerator.hh
     ${_root}/include/RMGVOutputScheme.hh
-    ${_root}/include/RMGVVertexGenerator.hh)
+    ${_root}/include/RMGVVertexGenerator.hh
+    ${_root}/include/RMGVertexOutputScheme.hh)
 
 set(PROJECT_SOURCES
     ${_root}/src/RMGExceptionHandler.cc
@@ -56,7 +57,8 @@ set(PROJECT_SOURCES
     ${_root}/src/RMGTrackingAction.cc
     ${_root}/src/RMGUserAction.cc
     ${_root}/src/RMGVertexConfinement.cc
-    ${_root}/src/RMGVertexFromFile.cc)
+    ${_root}/src/RMGVertexFromFile.cc
+    ${_root}/src/RMGVertexOutputScheme.cc)
 
 # Write RMGConfig.hh
 # no need to install, it is included in the header list above

--- a/src/RMGEventAction.cc
+++ b/src/RMGEventAction.cc
@@ -66,17 +66,16 @@ void RMGEventAction::BeginOfEventAction(const G4Event* event) {
 
 void RMGEventAction::EndOfEventAction(const G4Event* event) {
 
-  auto det_cons = RMGManager::Instance()->GetDetectorConstruction();
-  auto active_dets = det_cons->GetActiveDetectorList();
+  auto oschemes = fRunAction->GetAllOutputDataFields();
 
   // Check if any OutputScheme wants to discard this event.
-  for (const auto& d_type : active_dets) {
-    bool discard_event = fRunAction->GetOutputDataFields(d_type)->ShouldDiscardEvent(event);
+  for (const auto& oscheme : oschemes) {
+    bool discard_event = oscheme->ShouldDiscardEvent(event);
     if (discard_event) return;
   }
 
-  for (const auto& d_type : active_dets) {
-    fRunAction->GetOutputDataFields(d_type)->StoreEvent(event);
+  for (const auto& oscheme : oschemes) {
+    oscheme->StoreEvent(event);
   }
 
   // NOTE: G4analysisManager::AddNtupleRow() must be called here for event-oriented output

--- a/src/RMGEventAction.cc
+++ b/src/RMGEventAction.cc
@@ -69,13 +69,14 @@ void RMGEventAction::EndOfEventAction(const G4Event* event) {
   auto oschemes = fRunAction->GetAllOutputDataFields();
 
   // Check if any OutputScheme wants to discard this event.
+  bool discard_event = false;
   for (const auto& oscheme : oschemes) {
-    bool discard_event = oscheme->ShouldDiscardEvent(event);
-    if (discard_event) return;
+    discard_event = discard_event || oscheme->ShouldDiscardEvent(event);
+    if (discard_event) continue;
   }
 
   for (const auto& oscheme : oschemes) {
-    oscheme->StoreEvent(event);
+    if (oscheme->StoreAlways() || !discard_event) oscheme->StoreEvent(event);
   }
 
   // NOTE: G4analysisManager::AddNtupleRow() must be called here for event-oriented output

--- a/src/RMGGeneratorUtil.cc
+++ b/src/RMGGeneratorUtil.cc
@@ -153,7 +153,7 @@ G4ThreeVector RMGGeneratorUtil::rand(const G4Tubs* tub, bool on_surface) {
 
   auto phi = a + delta_a * _g4rand();
   auto z = h * (_g4rand() - 0.5);
-  auto R = _g4rand() * (r2 - r1) + r1;
+  auto R = std::sqrt(_g4rand() * (r2 * r2 - r1 * r1) + r1 * r1);
   auto s1_point = G4ThreeVector(std::cos(phi), std::sin(phi), 0);
 
   if (on_surface) {

--- a/src/RMGGermaniumOutputScheme.cc
+++ b/src/RMGGermaniumOutputScheme.cc
@@ -40,6 +40,7 @@ void RMGGermaniumOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) {
   const auto detectors = det_cons->GetDetectorMetadataMap();
 
   std::set<int> registered_uids;
+  std::set<std::string> registered_ntuples;
   for (auto&& det : detectors) {
     if (det.second.type != RMGHardware::kGermanium) continue;
 
@@ -47,10 +48,15 @@ void RMGGermaniumOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) {
     auto had_uid = registered_uids.emplace(det.second.uid);
     if (!had_uid.second) continue;
 
+    auto ntuple_name = this->GetNtupleName(det.second.uid);
+    auto had_name = registered_ntuples.emplace(ntuple_name);
+    if (!had_name.second) continue;
+
     auto id = rmg_man->RegisterNtuple(det.second.uid);
-    ana_man->CreateNtuple(this->GetNtupleName(det.second.uid), "Event data");
+    ana_man->CreateNtuple(ntuple_name, "Event data");
 
     ana_man->CreateNtupleIColumn(id, "evtid");
+    if (!fNtuplePerDetector) { ana_man->CreateNtupleIColumn(id, "det_uid"); }
     ana_man->CreateNtupleIColumn(id, "particle");
     ana_man->CreateNtupleDColumn(id, "edep");
     ana_man->CreateNtupleDColumn(id, "time");
@@ -124,21 +130,25 @@ void RMGGermaniumOutputScheme::StoreEvent(const G4Event* event) {
   auto rmg_man = RMGManager::Instance();
   if (rmg_man->IsPersistencyEnabled()) {
     RMGLog::OutDev(RMGLog::debug, "Filling persistent data vectors");
+    const auto ana_man = G4AnalysisManager::Instance();
 
     for (auto hit : *hit_coll->GetVector()) {
       if (!hit) continue;
       hit->Print();
 
-      const auto ana_man = G4AnalysisManager::Instance();
       auto ntupleid = rmg_man->GetNtupleID(hit->detector_uid);
 
-      ana_man->FillNtupleIColumn(ntupleid, 0, event->GetEventID());
-      ana_man->FillNtupleIColumn(ntupleid, 1, hit->particle_type);
-      ana_man->FillNtupleDColumn(ntupleid, 2, hit->energy_deposition / u::keV);
-      ana_man->FillNtupleDColumn(ntupleid, 3, hit->global_time / u::ns);
-      ana_man->FillNtupleDColumn(ntupleid, 4, hit->global_position.getX() / u::m);
-      ana_man->FillNtupleDColumn(ntupleid, 5, hit->global_position.getY() / u::m);
-      ana_man->FillNtupleDColumn(ntupleid, 6, hit->global_position.getZ() / u::m);
+      int col_id = 0;
+      ana_man->FillNtupleIColumn(ntupleid, col_id++, event->GetEventID());
+      if (!fNtuplePerDetector) {
+        ana_man->FillNtupleIColumn(ntupleid, col_id++, hit->detector_uid);
+      }
+      ana_man->FillNtupleIColumn(ntupleid, col_id++, hit->particle_type);
+      ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->energy_deposition / u::keV);
+      ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->global_time / u::ns);
+      ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->global_position.getX() / u::m);
+      ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->global_position.getY() / u::m);
+      ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->global_position.getZ() / u::m);
 
       // NOTE: must be called here for hit-oriented output
       ana_man->AddNtupleRow(ntupleid);

--- a/src/RMGHardware.cc
+++ b/src/RMGHardware.cc
@@ -34,6 +34,7 @@ namespace fs = std::filesystem;
 #include "RMGNavigationTools.hh"
 #include "RMGOpticalDetector.hh"
 #include "RMGOpticalOutputScheme.hh"
+#include "RMGVertexOutputScheme.hh"
 
 #include "magic_enum/magic_enum.hpp"
 
@@ -159,6 +160,11 @@ void RMGHardware::ConstructSDandField() {
     RMGLog::OutFormat(RMGLog::debug,
         "Registered new sensitive detector volume of type {}: {} (uid={}, lv={})",
         magic_enum::enum_name(v.type), pv->GetName().c_str(), v.uid, lv->GetName().c_str());
+  }
+
+  // also store primary vertex data, if we have any other output.
+  if (!fActiveOutputSchemes.empty()) {
+    fActiveOutputSchemes.emplace_back(std::make_shared<RMGVertexOutputScheme>());
   }
 
   std::string vec_repr;

--- a/src/RMGHardware.cc
+++ b/src/RMGHardware.cc
@@ -134,7 +134,12 @@ void RMGHardware::ConstructSDandField() {
       }
       sd_man->AddNewDetector(obj);
       active_dets.emplace(v.type, obj);
-      fActiveOutputSchemes.insert({v.type, output});
+
+      if (!output) {
+        RMGLog::OutDev(RMGLog::fatal, "No output scheme sensitive detector type '",
+            magic_enum::enum_name(v.type), "' implemented (implement me)");
+      }
+      fActiveOutputSchemes.emplace_back(output);
     }
 
     // now assign logical volumes to the sensitive detector

--- a/src/RMGHardware.cc
+++ b/src/RMGHardware.cc
@@ -37,6 +37,10 @@ namespace fs = std::filesystem;
 
 #include "magic_enum/magic_enum.hpp"
 
+G4ThreadLocal std::vector<std::shared_ptr<RMGVOutputScheme>> RMGHardware::fActiveOutputSchemes = {};
+
+G4ThreadLocal bool RMGHardware::fActiveDetectorsInitialized = false;
+
 RMGHardware::RMGHardware() { this->DefineCommands(); }
 
 G4VPhysicalVolume* RMGHardware::Construct() {
@@ -99,6 +103,7 @@ G4VPhysicalVolume* RMGHardware::Construct() {
 }
 
 void RMGHardware::ConstructSDandField() {
+  // setup thread-local data, called once for the master thread and once for each worker thread.
 
   // set up G4SDManager
   auto sd_man = G4SDManager::GetSDMpointer();

--- a/src/RMGManager.cc
+++ b/src/RMGManager.cc
@@ -322,6 +322,12 @@ void RMGManager::DefineCommands() {
       .SetGuidance("Set output file name for object persistency")
       .SetParameterName("filename", false)
       .SetStates(G4State_PreInit, G4State_Idle);
+
+  fOutputMessenger->DeclareProperty("NtuplePerDetector", fOutputNtuplePerDetector)
+      .SetGuidance("Create a ntuple for each sensitive detector to store hits. Otherwise, store "
+                   "all hits of one detector type in one ntuple.")
+      .SetParameterName("tree_per_det", false)
+      .SetStates(G4State_PreInit, G4State_Idle);
 }
 
 // vim: tabstop=2 shiftwidth=2 expandtab

--- a/src/RMGMasterGenerator.cc
+++ b/src/RMGMasterGenerator.cc
@@ -84,8 +84,8 @@ void RMGMasterGenerator::SetConfinement(RMGMasterGenerator::Confinement code) {
       break;
     case Confinement::kFromFile: fVertexGeneratorObj = std::make_unique<RMGVertexFromFile>(); break;
     default:
-      RMGLog::Out(RMGLog::fatal, "No sampling strategy for confinement '", fConfinement,
-          "' specified (implement me)");
+      RMGLog::Out(RMGLog::fatal, "No sampling strategy for confinement '",
+          static_cast<int>(fConfinement), "' specified (implement me)");
   }
   RMGLog::OutFormat(RMGLog::debug, "Primary vertex confinement strategy set to {}",
       magic_enum::enum_name<RMGMasterGenerator::Confinement>(code));
@@ -117,8 +117,8 @@ void RMGMasterGenerator::SetGenerator(RMGMasterGenerator::Generator gen) {
     case Generator::kUndefined:
     case Generator::kUserDefined: break;
     default:
-      RMGLog::Out(RMGLog::fatal, "No known implementation for generator '", fGenerator,
-          "' (implement me)");
+      RMGLog::Out(RMGLog::fatal, "No known implementation for generator '",
+          static_cast<int>(fGenerator), "' (implement me)");
   }
   RMGLog::OutFormat(RMGLog::debug, "Primary generator set to {}",
       magic_enum::enum_name<RMGMasterGenerator::Generator>(gen));

--- a/src/RMGRunAction.cc
+++ b/src/RMGRunAction.cc
@@ -69,15 +69,11 @@ void RMGRunAction::SetupAnalysisManager() {
 
   // do it only for activated detectors (have to ask to the manager)
   auto det_cons = RMGManager::Instance()->GetDetectorConstruction();
-  for (const auto& d_type : det_cons->GetActiveDetectorList()) {
+  for (const auto& oscheme : det_cons->GetAllActiveOutputSchemes()) {
 
-    fOutputDataFields[d_type] = det_cons->GetActiveOutputScheme(d_type);
-    if (!fOutputDataFields[d_type]) {
-      RMGLog::OutDev(RMGLog::fatal, "No output scheme sensitive detector type '",
-          magic_enum::enum_name(d_type), "' implemented (implement me)");
-    }
+    fOutputDataFields.emplace_back(oscheme);
 
-    fOutputDataFields[d_type]->AssignOutputNames(ana_man);
+    oscheme->AssignOutputNames(ana_man);
   }
 }
 

--- a/src/RMGRunAction.cc
+++ b/src/RMGRunAction.cc
@@ -73,6 +73,7 @@ void RMGRunAction::SetupAnalysisManager() {
 
     fOutputDataFields.emplace_back(oscheme);
 
+    oscheme->SetNtuplePerDetector(RMGManager::Instance()->GetOutputNtuplePerDetector());
     oscheme->AssignOutputNames(ana_man);
   }
 }

--- a/src/RMGStackingAction.cc
+++ b/src/RMGStackingAction.cc
@@ -29,7 +29,7 @@ RMGStackingAction::RMGStackingAction(RMGRunAction* runaction) : fRunAction(runac
 G4ClassificationOfNewTrack RMGStackingAction::ClassifyNewTrack(const G4Track* aTrack) {
   std::optional<G4ClassificationOfNewTrack> new_status = std::nullopt;
   for (auto& el : fRunAction->GetAllOutputDataFields()) {
-    auto request_status = el.second->StackingActionClassify(aTrack, fStage);
+    auto request_status = el->StackingActionClassify(aTrack, fStage);
     if (!request_status.has_value()) continue; // this output scheme does not care.
 
     if (!new_status.has_value() || new_status.value() == request_status.value()) {
@@ -48,7 +48,7 @@ void RMGStackingAction::NewStage() {
   // we can have only one result from all output schemes, if we have
   std::optional<bool> should_do_stage = std::nullopt;
   for (auto& el : fRunAction->GetAllOutputDataFields()) {
-    auto request_stage = el.second->StackingActionNewStage(fStage);
+    auto request_stage = el->StackingActionNewStage(fStage);
     if (!request_stage.has_value()) continue; // this output scheme does not care.
 
     if (!should_do_stage.has_value() || should_do_stage.value() == request_stage.value()) {

--- a/src/RMGVertexConfinement.cc
+++ b/src/RMGVertexConfinement.cc
@@ -359,18 +359,18 @@ void RMGVertexConfinement::InitializeGeometricalVolumes() {
 
   // no physical volume is specified nor at initialization or later
   for (const auto& d : fGeomVolumeData) {
-    if (d.solid_type == kSphere) {
+    if (d.solid_type == GeometricalSolidType::kSphere) {
       fGeomVolumeSolids.emplace_back(nullptr, G4RotationMatrix(), d.volume_center,
           new G4Sphere("RMGVertexConfinement::fGeomSamplingShape::Sphere/" +
                            std::to_string(fGeomVolumeSolids.size() + 1),
               d.sphere_inner_radius, d.sphere_outer_radius, 0, CLHEP::twopi, 0, CLHEP::pi));
-    } else if (d.solid_type == kCylinder) {
+    } else if (d.solid_type == GeometricalSolidType::kCylinder) {
       fGeomVolumeSolids.emplace_back(nullptr, G4RotationMatrix(), d.volume_center,
           new G4Tubs("RMGVertexConfinement::fGeomSamplingShape::Cylinder/" +
                          std::to_string(fGeomVolumeSolids.size() + 1),
               d.cylinder_inner_radius, d.cylinder_outer_radius, 0.5 * d.cylinder_height,
               d.cylinder_starting_angle, d.cylinder_spanning_angle));
-    } else if (d.solid_type == kBox) {
+    } else if (d.solid_type == GeometricalSolidType::kBox) {
       fGeomVolumeSolids.emplace_back(nullptr, G4RotationMatrix(), d.volume_center,
           new G4Box("RMGVertexConfinement::fGeomSamplingShape::Box/" +
                         std::to_string(fGeomVolumeSolids.size() + 1),

--- a/src/RMGVertexOutputScheme.cc
+++ b/src/RMGVertexOutputScheme.cc
@@ -1,0 +1,123 @@
+// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option) any
+// later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "RMGVertexOutputScheme.hh"
+
+#include "G4AnalysisManager.hh"
+#include "G4Event.hh"
+
+#include "RMGLog.hh"
+#include "RMGManager.hh"
+
+namespace u = CLHEP;
+
+RMGVertexOutputScheme::RMGVertexOutputScheme() { this->DefineCommands(); }
+
+// invoked in RMGRunAction::SetupAnalysisManager()
+void RMGVertexOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) {
+  if (fSkipPrimaryVertexOutput) return;
+
+  auto vid = RMGManager::Instance()->RegisterNtuple(-1);
+  ana_man->CreateNtuple("vertices", "Primary vertex data");
+
+  ana_man->CreateNtupleIColumn(vid, "evtid");
+  ana_man->CreateNtupleDColumn(vid, "time");
+  ana_man->CreateNtupleDColumn(vid, "xloc");
+  ana_man->CreateNtupleDColumn(vid, "yloc");
+  ana_man->CreateNtupleDColumn(vid, "zloc");
+  ana_man->CreateNtupleIColumn(vid, "n_part");
+
+  ana_man->FinishNtuple(vid);
+
+  if (fStorePrimaryParticleInformation) {
+    auto pid = RMGManager::Instance()->RegisterNtuple(-2);
+    ana_man->CreateNtuple("particles", "Primary particle data");
+
+    ana_man->CreateNtupleIColumn(pid, "evtid");
+    ana_man->CreateNtupleIColumn(pid, "vertexid");
+    ana_man->CreateNtupleIColumn(pid, "particle");
+    ana_man->CreateNtupleDColumn(pid, "px");
+    ana_man->CreateNtupleDColumn(pid, "py");
+    ana_man->CreateNtupleDColumn(pid, "pz");
+    ana_man->CreateNtupleDColumn(pid, "ekin");
+
+    ana_man->FinishNtuple(pid);
+  }
+}
+
+// invoked in RMGEventAction::EndOfEventAction()
+void RMGVertexOutputScheme::StoreEvent(const G4Event* event) {
+  if (fSkipPrimaryVertexOutput) return;
+
+  int n_vertex = event->GetNumberOfPrimaryVertex();
+
+  auto rmg_man = RMGManager::Instance();
+  if (rmg_man->IsPersistencyEnabled()) {
+    RMGLog::OutDev(RMGLog::debug, "Filling persistent data vectors on primary particles");
+    const auto ana_man = G4AnalysisManager::Instance();
+    auto vntupleid = rmg_man->GetNtupleID(-1);
+    auto pntupleid = fStorePrimaryParticleInformation ? rmg_man->GetNtupleID(-2) : -1;
+
+    for (int i = 0; i < n_vertex; i++) {
+      auto primary_vertex = event->GetPrimaryVertex(i);
+      int n_primaries = primary_vertex->GetNumberOfParticle();
+
+      int vcol_id = 0;
+      ana_man->FillNtupleIColumn(vntupleid, vcol_id++, event->GetEventID());
+      ana_man->FillNtupleDColumn(vntupleid, vcol_id++, primary_vertex->GetT0() / u::ns);
+      ana_man->FillNtupleDColumn(vntupleid, vcol_id++, primary_vertex->GetX0() / u::m);
+      ana_man->FillNtupleDColumn(vntupleid, vcol_id++, primary_vertex->GetY0() / u::m);
+      ana_man->FillNtupleDColumn(vntupleid, vcol_id++, primary_vertex->GetZ0() / u::m);
+      ana_man->FillNtupleIColumn(vntupleid, vcol_id++, n_primaries);
+
+      // NOTE: must be called here for hit-oriented output
+      ana_man->AddNtupleRow(vntupleid);
+
+      if (fStorePrimaryParticleInformation) {
+        for (int j = 0; j < n_primaries; j++) {
+          auto primary = primary_vertex->GetPrimary(j);
+
+          int pcol_id = 0;
+          ana_man->FillNtupleIColumn(pntupleid, pcol_id++, event->GetEventID());
+          ana_man->FillNtupleIColumn(pntupleid, pcol_id++, j);
+          ana_man->FillNtupleIColumn(pntupleid, pcol_id++, primary->GetPDGcode());
+          ana_man->FillNtupleDColumn(pntupleid, pcol_id++, primary->GetMomentum().getX() / u::MeV);
+          ana_man->FillNtupleDColumn(pntupleid, pcol_id++, primary->GetMomentum().getY() / u::MeV);
+          ana_man->FillNtupleDColumn(pntupleid, pcol_id++, primary->GetMomentum().getZ() / u::MeV);
+          ana_man->FillNtupleDColumn(pntupleid, pcol_id++, primary->GetKineticEnergy() / u::MeV);
+
+          // NOTE: must be called here for hit-oriented output
+          ana_man->AddNtupleRow(pntupleid);
+        }
+      }
+    }
+  }
+}
+
+void RMGVertexOutputScheme::DefineCommands() {
+
+  fMessenger = std::make_unique<G4GenericMessenger>(this, "/RMG/Output/Vertex/",
+      "Commands for controlling output of primary vertices.");
+
+  fMessenger->DeclareProperty("StorePrimaryParticleInformation", fStorePrimaryParticleInformation)
+      .SetGuidance("Store information on primary particle details (not only vertex data).")
+      .SetStates(G4State_Idle);
+
+  fMessenger->DeclareProperty("SkipPrimaryVertexOutput", fSkipPrimaryVertexOutput)
+      .SetGuidance("Do not store vertex/primary particle data.")
+      .SetStates(G4State_Idle);
+}
+
+// vim: tabstop=2 shiftwidth=2 expandtab


### PR DESCRIPTION
* vertex output scheme, both for
  * vertex positions (enabled by default if any other output is enabled), as well as
  * primary particle info, has to be enabled manually
* flag to switch to a flat(ter) output structure, i.e. one ntuple per detector type
* also fix a regression in MT mode from #80 (didn't a large impact until this PR)
* also fix a bug in the cylindrical sampling in `RMGTools` (unrelated to output)