### PR TITLE
Add a way for a (library) user to add custom output schemes and user actions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -49,7 +49,7 @@ ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
 IncludeBlocks: Regroup
 IncludeCategories:
-  - Regex:           '<[[:alnum:].]+>'
+  - Regex:           '<[[:alnum:]._]+>'
     Priority:        1
     CaseSensitive:   false
   - Regex:           '^"(G4|globals\.hh|Randomize\.hh|CLHEP)'
@@ -57,9 +57,6 @@ IncludeCategories:
     CaseSensitive:   false
   - Regex:           '^"RMG'
     Priority:        3
-    CaseSensitive:   false
-  - Regex:           '.*'
-    Priority:        4
     CaseSensitive:   false
   - Regex:           '.*'
     Priority:        4

--- a/include/RMGManager.hh
+++ b/include/RMGManager.hh
@@ -27,6 +27,7 @@
 
 #include "RMGExceptionHandler.hh"
 #include "RMGLog.hh"
+#include "RMGUserInit.hh"
 
 class G4VUserPhysicsList;
 class RMGHardware;
@@ -52,6 +53,7 @@ class RMGManager {
     G4VisManager* GetG4VisManager();
     RMGHardware* GetDetectorConstruction();
     G4VUserPhysicsList* GetProcessesList();
+    [[nodiscard]] inline auto GetUserInit() const { return fUserInit; }
     [[nodiscard]] inline int GetPrintModulo() const { return fPrintModulo; }
 
     inline bool IsExecSequential() {
@@ -72,7 +74,7 @@ class RMGManager {
     }
     inline void SetUserInit(RMGHardware* det) { fDetectorConstruction = det; }
     inline void SetUserInit(G4VUserPhysicsList* proc) { fPhysicsList = proc; }
-    inline void SetUserInit(RMGUserAction* ua) { fUserAction = ua; }
+
     inline void SetInteractive(bool flag = true) { fInteractive = flag; }
     inline void SetNumberOfThreads(int nthreads) { fNThreads = nthreads; }
     inline void SetPrintModulo(int n_ev) { fPrintModulo = n_ev > 0 ? n_ev : -1; }
@@ -137,10 +139,13 @@ class RMGManager {
     std::unique_ptr<G4RunManager> fG4RunManager = nullptr;
     std::unique_ptr<G4VisManager> fG4VisManager = nullptr;
 
+    RMGExceptionHandler* fExceptionHandler = nullptr;
     G4VUserPhysicsList* fPhysicsList = nullptr;
     RMGHardware* fDetectorConstruction = nullptr;
+
     RMGUserAction* fUserAction = nullptr;
-    RMGExceptionHandler* fExceptionHandler = nullptr;
+    // store partial custom actions to be used later in RMGUserAction
+    std::shared_ptr<RMGUserInit> fUserInit;
 
     // messenger stuff
     std::unique_ptr<G4GenericMessenger> fMessenger;

--- a/include/RMGUserInit.hh
+++ b/include/RMGUserInit.hh
@@ -1,0 +1,90 @@
+// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option) any
+// later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef _RMG_USER_INIT_HH_
+#define _RMG_USER_INIT_HH_
+
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "G4UserSteppingAction.hh"
+#include "G4UserTrackingAction.hh"
+
+#include "RMGVOutputScheme.hh"
+
+class RMGUserInit {
+
+  public:
+
+    RMGUserInit() = default;
+    ~RMGUserInit() = default;
+
+    RMGUserInit(RMGUserInit const&) = delete;
+    RMGUserInit& operator=(RMGUserInit const&) = delete;
+    RMGUserInit(RMGUserInit&&) = delete;
+    RMGUserInit& operator=(RMGUserInit&&) = delete;
+
+    // getters
+    [[nodiscard]] inline auto GetSteppingActions() const { return fSteppingActions; }
+    [[nodiscard]] inline auto GetTrackingActions() const { return fTrackingActions; }
+    [[nodiscard]] inline auto GetOutputSchemes() const { return fOutputSchemes; }
+
+    // setters
+    template<typename T, typename... Args> inline void AddSteppingAction(Args&&... args) {
+      Add<T>(&fSteppingActions, std::forward<Args>(args)...);
+    }
+
+    template<typename T, typename... Args> inline void AddTrackingAction(Args&&... args) {
+      Add<T>(&fTrackingActions, std::forward<Args>(args)...);
+    }
+
+    template<typename T, typename... Args> inline void AddOutputScheme(Args&&... args) {
+      Add<T>(&fOutputSchemes, std::forward<Args>(args)...);
+    }
+
+  private:
+
+    template<typename T> using late_init_fn = std::function<std::unique_ptr<T>()>;
+    template<typename T> using late_init_vec = std::vector<late_init_fn<T>>;
+
+    template<typename B, typename T, typename... Args>
+    inline late_init_fn<B> CreateInit(Args&&... args) {
+      return std::bind(&std::make_unique<T, Args&...>, std::forward<Args>(args)...);
+    }
+    template<typename B, typename T> inline late_init_fn<B> CreateInit() {
+      return [] { return std::make_unique<T>(); };
+    }
+
+    template<typename T, typename B, typename... Args>
+    inline void Add(late_init_vec<B>* vec, Args&&... args) {
+      static_assert(std::is_base_of<B, T>::value);
+
+      // capture the passed arguments for the constructor to be called later.
+      auto create = CreateInit<B, T>(std::forward<Args>(args)...);
+      vec->emplace_back(std::move(create));
+    }
+
+    // store partial custom actions to be used later in RMGUserAction
+    late_init_vec<G4UserSteppingAction> fSteppingActions;
+    late_init_vec<G4UserTrackingAction> fTrackingActions;
+    late_init_vec<RMGVOutputScheme> fOutputSchemes;
+};
+
+#endif
+
+// vim: tabstop=2 shiftwidth=2 expandtab

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ set(PROJECT_PUBLIC_HEADERS
     ${_root}/include/RMGTools.hh
     ${_root}/include/RMGTrackingAction.hh
     ${_root}/include/RMGUserAction.hh
+    ${_root}/include/RMGUserInit.hh
     ${_root}/include/RMGVertexConfinement.hh
     ${_root}/include/RMGVertexFromFile.hh
     ${_root}/include/RMGVGenerator.hh

--- a/src/RMGHardware.cc
+++ b/src/RMGHardware.cc
@@ -31,6 +31,7 @@ namespace fs = std::filesystem;
 #include "RMGGermaniumOutputScheme.hh"
 #include "RMGHardwareMessenger.hh"
 #include "RMGLog.hh"
+#include "RMGManager.hh"
 #include "RMGNavigationTools.hh"
 #include "RMGOpticalDetector.hh"
 #include "RMGOpticalOutputScheme.hh"
@@ -165,6 +166,11 @@ void RMGHardware::ConstructSDandField() {
   // also store primary vertex data, if we have any other output.
   if (!fActiveOutputSchemes.empty()) {
     fActiveOutputSchemes.emplace_back(std::make_shared<RMGVertexOutputScheme>());
+  }
+
+  // Also add user-provided output schemes.
+  for (const auto& os : RMGManager::Instance()->GetUserInit()->GetOutputSchemes()) {
+    fActiveOutputSchemes.emplace_back(os());
   }
 
   std::string vec_repr;

--- a/src/RMGManager.cc
+++ b/src/RMGManager.cc
@@ -21,13 +21,13 @@
 #include <string>
 #include <vector>
 
-#include "G4Threading.hh"
 #ifdef G4MULTITHREADED
 #include "G4MTRunManager.hh"
 #endif
 #include "G4Backtrace.hh"
 #include "G4GenericMessenger.hh"
 #include "G4StateManager.hh"
+#include "G4Threading.hh"
 #include "G4UIExecutive.hh"
 #include "G4UImanager.hh"
 #include "G4VUserPhysicsList.hh"
@@ -41,6 +41,7 @@
 #include "RMGPhysics.hh"
 #include "RMGTools.hh"
 #include "RMGUserAction.hh"
+#include "RMGUserInit.hh"
 
 #if RMG_HAS_ROOT
 #include "TEnv.h"
@@ -63,6 +64,8 @@ RMGManager::RMGManager(std::string app_name, int argc, char** argv)
 
   // limit Geant4 stacktrace dumping to segfaults
   G4Backtrace::DefaultSignals() = std::set<int>{SIGSEGV};
+
+  fUserInit = std::make_shared<RMGUserInit>();
 
   this->DefineCommands();
 }


### PR DESCRIPTION
* Also remove the old way of overriding the RMGUserAction. This is not well-working, as most of remage's behaviour somehow depends on the setup in it.
* Add RMGUserInit to hold lazy-initializers for different user-amendable output scheme/action classes. The lazy-initialization is necessary, as some of the things might be instantiated for multiple threads/at a later point of the simulation.