### PR TITLE
output: add units to ntuple column names

### DIFF
--- a/src/RMGGermaniumOutputScheme.cc
+++ b/src/RMGGermaniumOutputScheme.cc
@@ -58,11 +58,11 @@ void RMGGermaniumOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) {
     ana_man->CreateNtupleIColumn(id, "evtid");
     if (!fNtuplePerDetector) { ana_man->CreateNtupleIColumn(id, "det_uid"); }
     ana_man->CreateNtupleIColumn(id, "particle");
-    ana_man->CreateNtupleDColumn(id, "edep");
-    ana_man->CreateNtupleDColumn(id, "time");
-    ana_man->CreateNtupleDColumn(id, "xloc");
-    ana_man->CreateNtupleDColumn(id, "yloc");
-    ana_man->CreateNtupleDColumn(id, "zloc");
+    ana_man->CreateNtupleDColumn(id, "edep_in_keV");
+    ana_man->CreateNtupleDColumn(id, "time_in_ns");
+    ana_man->CreateNtupleDColumn(id, "xloc_in_m");
+    ana_man->CreateNtupleDColumn(id, "yloc_in_m");
+    ana_man->CreateNtupleDColumn(id, "zloc_in_m");
 
     ana_man->FinishNtuple(id);
   }

--- a/src/RMGOpticalOutputScheme.cc
+++ b/src/RMGOpticalOutputScheme.cc
@@ -56,8 +56,8 @@ void RMGOpticalOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) {
 
     ana_man->CreateNtupleIColumn(id, "evtid");
     if (!fNtuplePerDetector) { ana_man->CreateNtupleIColumn(id, "det_uid"); }
-    ana_man->CreateNtupleDColumn(id, "wavelength");
-    ana_man->CreateNtupleDColumn(id, "time");
+    ana_man->CreateNtupleDColumn(id, "wavelength_in_nm");
+    ana_man->CreateNtupleDColumn(id, "time_in_ns");
 
     ana_man->FinishNtuple(id);
   }

--- a/src/RMGScintillatorOutputScheme.cc
+++ b/src/RMGScintillatorOutputScheme.cc
@@ -58,14 +58,14 @@ void RMGScintillatorOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) 
     ana_man->CreateNtupleIColumn(id, "evtid");
     if (!fNtuplePerDetector) { ana_man->CreateNtupleIColumn(id, "det_uid"); }
     ana_man->CreateNtupleIColumn(id, "particle");
-    ana_man->CreateNtupleDColumn(id, "edep");
-    ana_man->CreateNtupleDColumn(id, "time");
-    ana_man->CreateNtupleDColumn(id, "xloc_pre");
-    ana_man->CreateNtupleDColumn(id, "yloc_pre");
-    ana_man->CreateNtupleDColumn(id, "zloc_pre");
-    ana_man->CreateNtupleDColumn(id, "xloc_post");
-    ana_man->CreateNtupleDColumn(id, "yloc_post");
-    ana_man->CreateNtupleDColumn(id, "zloc_post");
+    ana_man->CreateNtupleDColumn(id, "edep_in_keV");
+    ana_man->CreateNtupleDColumn(id, "time_in_ns");
+    ana_man->CreateNtupleDColumn(id, "xloc_pre_in_m");
+    ana_man->CreateNtupleDColumn(id, "yloc_pre_in_m");
+    ana_man->CreateNtupleDColumn(id, "zloc_pre_in_m");
+    ana_man->CreateNtupleDColumn(id, "xloc_post_in_m");
+    ana_man->CreateNtupleDColumn(id, "yloc_post_in_m");
+    ana_man->CreateNtupleDColumn(id, "zloc_post_in_m");
     ana_man->CreateNtupleDColumn(id, "v_pre");
     ana_man->CreateNtupleDColumn(id, "v_post");
 

--- a/src/RMGScintillatorOutputScheme.cc
+++ b/src/RMGScintillatorOutputScheme.cc
@@ -66,8 +66,8 @@ void RMGScintillatorOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) 
     ana_man->CreateNtupleDColumn(id, "xloc_post_in_m");
     ana_man->CreateNtupleDColumn(id, "yloc_post_in_m");
     ana_man->CreateNtupleDColumn(id, "zloc_post_in_m");
-    ana_man->CreateNtupleDColumn(id, "v_pre");
-    ana_man->CreateNtupleDColumn(id, "v_post");
+    ana_man->CreateNtupleDColumn(id, "beta_pre");
+    ana_man->CreateNtupleDColumn(id, "beta_post");
 
     ana_man->FinishNtuple(id);
   }

--- a/src/RMGVertexOutputScheme.cc
+++ b/src/RMGVertexOutputScheme.cc
@@ -33,10 +33,10 @@ void RMGVertexOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) {
       ana_man->CreateNtuple("vertices", "Primary vertex data"));
 
   ana_man->CreateNtupleIColumn(vid, "evtid");
-  ana_man->CreateNtupleDColumn(vid, "time");
-  ana_man->CreateNtupleDColumn(vid, "xloc");
-  ana_man->CreateNtupleDColumn(vid, "yloc");
-  ana_man->CreateNtupleDColumn(vid, "zloc");
+  ana_man->CreateNtupleDColumn(vid, "time_in_ns");
+  ana_man->CreateNtupleDColumn(vid, "xloc_in_m");
+  ana_man->CreateNtupleDColumn(vid, "yloc_in_m");
+  ana_man->CreateNtupleDColumn(vid, "zloc_in_m");
   ana_man->CreateNtupleIColumn(vid, "n_part");
 
   ana_man->FinishNtuple(vid);
@@ -48,10 +48,10 @@ void RMGVertexOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) {
     ana_man->CreateNtupleIColumn(pid, "evtid");
     ana_man->CreateNtupleIColumn(pid, "vertexid");
     ana_man->CreateNtupleIColumn(pid, "particle");
-    ana_man->CreateNtupleDColumn(pid, "px");
-    ana_man->CreateNtupleDColumn(pid, "py");
-    ana_man->CreateNtupleDColumn(pid, "pz");
-    ana_man->CreateNtupleDColumn(pid, "ekin");
+    ana_man->CreateNtupleDColumn(pid, "px_in_MeV");
+    ana_man->CreateNtupleDColumn(pid, "py_in_MeV");
+    ana_man->CreateNtupleDColumn(pid, "pz_in_MeV");
+    ana_man->CreateNtupleDColumn(pid, "ekin_in_MeV");
 
     ana_man->FinishNtuple(pid);
   }


### PR DESCRIPTION
It is apparently not possible to attach a comment to an ntuple column (at least with `G4VAnalysisManager`), so we have to store the information in the column name.

I am also working on a short python script that parses remage's output HDF5 files and upgrades them to proper LH5 data files, stripping those units again from the column names...