### PR TITLE
make clang-tidy happy with RMGnCapture

### DIFF
--- a/include/RMGGrabmayrGCReader.hh
+++ b/include/RMGGrabmayrGCReader.hh
@@ -38,11 +38,11 @@ struct GammaCascadeLine {
 class RMGGrabmayrGCReader {
   public:
 
-    static G4ThreadLocal RMGGrabmayrGCReader* GetInstance();
+    static RMGGrabmayrGCReader* GetInstance();
     ~RMGGrabmayrGCReader();
     // RMGGrabmayrGCReader& operator=(const RMGGrabmayrGCReader&) = delete;
 
-    G4bool IsApplicable(G4int a, G4int z);
+    G4bool IsApplicable(G4int z, G4int a);
     void CloseFiles();
 
     GammaCascadeLine GetNextEntry(G4int z, G4int a);
@@ -57,9 +57,9 @@ class RMGGrabmayrGCReader {
     std::unique_ptr<G4GenericMessenger> fGenericMessenger;
     G4int fGammaCascadeRandomStartLocation = 0;
 
-    void SetGammaCascadeFile(const G4int z, const G4int a, const G4String file_name);
-    void SetGammaCascadeRandomStartLocation(const int answer);
-    void SetStartLocation(std::ifstream& file);
+    void SetGammaCascadeFile(G4int z, G4int a, G4String file_name);
+    void SetGammaCascadeRandomStartLocation(int answer);
+    void SetStartLocation(std::ifstream& file) const;
 
     void RandomizeFiles();
     void DefineCommands();

--- a/include/RMGNeutronCaptureProcess.hh
+++ b/include/RMGNeutronCaptureProcess.hh
@@ -25,7 +25,7 @@ class RMGNeutronCaptureProcess : public G4HadronicProcess {
 
     explicit RMGNeutronCaptureProcess(const G4String& processName = "RMGnCapture");
 
-    virtual ~RMGNeutronCaptureProcess();
+    virtual ~RMGNeutronCaptureProcess() = default;
 
     G4bool IsApplicable(const G4ParticleDefinition& aParticleType) final;
 

--- a/src/RMGGrabmayrGCReader.cc
+++ b/src/RMGGrabmayrGCReader.cc
@@ -69,7 +69,7 @@ GammaCascadeLine RMGGrabmayrGCReader::GetNextEntry(G4int z, G4int a) {
 }
 
 
-void RMGGrabmayrGCReader::SetStartLocation(std::ifstream& file) {
+void RMGGrabmayrGCReader::SetStartLocation(std::ifstream& file) const {
   if (!file.is_open())
     RMGLog::Out(RMGLog::fatal, "The file is not open to set start location! Exit.");
   file.clear();                 // clear EOF flag

--- a/src/RMGNeutronCaptureProcess.cc
+++ b/src/RMGNeutronCaptureProcess.cc
@@ -40,8 +40,6 @@ RMGNeutronCaptureProcess::RMGNeutronCaptureProcess(const G4String& processName)
   AddDataSet(new G4NeutronCaptureXS());
 }
 
-RMGNeutronCaptureProcess::~RMGNeutronCaptureProcess() {}
-
 G4bool RMGNeutronCaptureProcess::IsApplicable(const G4ParticleDefinition& aParticleType) {
   return (&aParticleType == G4Neutron::Neutron());
 }
@@ -51,7 +49,7 @@ G4VParticleChange* RMGNeutronCaptureProcess::PostStepDoIt(const G4Track& aTrack,
   // Get the proposed result from the "normal" process
   G4VParticleChange* ProposedResult = G4HadronicProcess::PostStepDoIt(aTrack, aStep);
 
-  RMGGrabmayrGCReader* CascadeReader = RMGGrabmayrGCReader::GetInstance();
+  auto CascadeReader = RMGGrabmayrGCReader::GetInstance();
 
   G4int nSec = ProposedResult->GetNumberOfSecondaries();
   G4int z;
@@ -100,20 +98,20 @@ G4VParticleChange* RMGNeutronCaptureProcess::PostStepDoIt(const G4Track& aTrack,
   theTotalResult->SetNumberOfSecondaries(input.m + 1);
   G4IonTable* theTable = G4IonTable::GetIonTable();
 
-  G4ParticleDefinition* particleDef_nuc = theTable->GetIon(z, a + 1, (double)(input.em * u::keV));
-  G4DynamicParticle* particle_nuc = new G4DynamicParticle(particleDef_nuc, G4RandomDirection());
-  G4Track* secondary_nuc = new G4Track(particle_nuc, time, location);
+  auto particleDef_nuc = theTable->GetIon(z, a + 1, (double)(input.em * u::keV));
+  auto particle_nuc = new G4DynamicParticle(particleDef_nuc, G4RandomDirection());
+  auto secondary_nuc = new G4Track(particle_nuc, time, location);
 
   // secondary_nuc->SetCreatorModelID(idModel); No idea what this should be. Not relevant?
   secondary_nuc->SetWeight(fWeight);
   secondary_nuc->SetTouchableHandle(aTrack.GetTouchableHandle());
   theTotalResult->AddSecondary(secondary_nuc);
 
+  auto particleDef_gamma = G4Gamma::Gamma();
   for (const G4int energy : input.eg) {
-    G4ParticleDefinition* particleDef_gamma = G4Gamma::Gamma();
-    G4DynamicParticle* particle_gamma =
+    auto particle_gamma =
         new G4DynamicParticle(particleDef_gamma, energy * u::keV, G4RandomDirection());
-    G4Track* secondary_gamma = new G4Track(particle_gamma, time, location);
+    auto secondary_gamma = new G4Track(particle_gamma, time, location);
     secondary_gamma->SetWeight(fWeight);
     secondary_gamma->SetTouchableHandle(aTrack.GetTouchableHandle());
     secondary_gamma->SetKineticEnergy(energy * u::keV);


### PR DESCRIPTION
/cc @EricMEsch 

this should not change any functionality, and just fixes complaints by clang-tidy. Mostly:

* `const` specifiers missing or ignored
* non-matching function parameter names between declaration and definition