### PR TITLE
Make ConstructOptical() virtual in RMGPhysics to allow customization through inheritance

### DIFF
--- a/include/RMGPhysics.hh
+++ b/include/RMGPhysics.hh
@@ -94,7 +94,7 @@ class RMGPhysics : public G4VModularPhysicsList {
 
     void ConstructParticle() override;
     void ConstructProcess() override;
-    void ConstructOptical();
+    virtual void ConstructOptical();
 
   private:
 


### PR DESCRIPTION
Making the `ConstructOptical()` function virtual would allow to derive from `RMGPhysics` in User applications, changing some optical processes while keeping the rest "normal". Without this, the `ConstructProcess()` function would have to be overwritten to call a user created version of the `ConstructOptical()` function. 