### PR TITLE
Only delay OpticalPhotons if discard macro is set

### DIFF
--- a/src/RMGGermaniumOutputScheme.cc
+++ b/src/RMGGermaniumOutputScheme.cc
@@ -167,7 +167,7 @@ std::optional<G4ClassificationOfNewTrack> RMGGermaniumOutputScheme::StackingActi
   // we are only interested in stacking optical photons into stage 1 after stage 0 finished.
   if (stage != 0) return std::nullopt;
 
-  // defer tracking of optical photons, irrespective of our settings.
+  // defer tracking of optical photons.
   if (fDiscardPhotonsIfNoGermaniumEdep &&
       aTrack->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition())
     return fWaiting;

--- a/src/RMGGermaniumOutputScheme.cc
+++ b/src/RMGGermaniumOutputScheme.cc
@@ -168,7 +168,9 @@ std::optional<G4ClassificationOfNewTrack> RMGGermaniumOutputScheme::StackingActi
   if (stage != 0) return std::nullopt;
 
   // defer tracking of optical photons, irrespective of our settings.
-  if (aTrack->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition()) return fWaiting;
+  if (fDiscardPhotonsIfNoGermaniumEdep &&
+      aTrack->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition())
+    return fWaiting;
   return std::nullopt;
 }
 

--- a/src/RMGIsotopeFilterOutputScheme.cc
+++ b/src/RMGIsotopeFilterOutputScheme.cc
@@ -65,7 +65,9 @@ std::optional<G4ClassificationOfNewTrack> RMGIsotopeFilterOutputScheme::
   if (stage != 0) return std::nullopt;
 
   // defer tracking of optical photons.
-  if (aTrack->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition()) return fWaiting;
+  if (fDiscardPhotonsIfIsotopeNotProduced &&
+      aTrack->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition())
+    return fWaiting;
   return std::nullopt;
 }
 


### PR DESCRIPTION
Currently, the optical photons will always be put on the waiting stack, even if the discard macro is not set. This means, they will be simulated anyways, but will consume (a lot of) memory on the stack while they are waiting.

This will only put them on the stack if the possibility exists for them to be discarded later. 