### PR TITLE
remage-to-lh5: do not do a dry-run automatically

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -49,7 +49,7 @@ ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
 IncludeBlocks: Regroup
 IncludeCategories:
-  - Regex:           '<[[:alnum:]._]+>'
+  - Regex:           '<[[:alnum:]._/]+>'
     Priority:        1
     CaseSensitive:   false
   - Regex:           '^"(G4|globals\.hh|Randomize\.hh|CLHEP)'

--- a/src/RMGRunAction.cc
+++ b/src/RMGRunAction.cc
@@ -265,13 +265,10 @@ void RMGRunAction::PostprocessOutputFile() const {
   }
 
 #if RMG_HAS_HDF5
-  if (!RMGConvertLH5::ConvertToLH5(worker_tmp.string(), true)) {
-    RMGLog::Out(RMGLog::error, "Conversion of output file ", worker_tmp.string(),
-        " to LH5 failed. The temporary output file is unchanged.");
-    return;
-  }
+  // note: do not do a dry-run here, as it takes a lot of memory.
   if (!RMGConvertLH5::ConvertToLH5(worker_tmp.string(), false)) {
-    RMGLog::Out(RMGLog::error, "Conversion of output file ", worker_tmp.string(), " to LH5 failed");
+    RMGLog::Out(RMGLog::error, "Conversion of output file ", worker_tmp.string(),
+        " to LH5 failed. Data is potentially corrupted.");
     return;
   }
 #else


### PR DESCRIPTION

* this should decrease the peak memory usage substantially
* also for the after-run conversion