### PR TITLE
add option to output float32 instead of float64 for some fields

### DIFF
--- a/docs/rmg-commands.rst
+++ b/docs/rmg-commands.rst
@@ -166,6 +166,8 @@ Commands for controlling output from hits in germanium detectors.
     * *SetEdepCutHigh*: ``Set an upper energy cut that has to be met for this event to be stored.``
     * *AddDetectorForEdepThreshold*: ``Take this detector into account for the filtering by /EdepThreshold.``
     * *DiscardPhotonsIfNoGermaniumEdep*: ``Discard optical photons (before simulating them), if no edep in germanium detectors occurred in the same event.``
+    * *StoreSinglePrecisionPosition*: ``Use float32 (instead of float64) for position output.``
+    * *StoreSinglePrecisionEnergy*: ``Use float32 (instead of float64) for energy output.``
 
 Command /RMG/Output/Germanium/SetEdepCutLow
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -217,6 +219,24 @@ Discard optical photons (before simulating them), if no edep in germanium detect
     * **Parameter type**: ``b``
     * **Omittable**: ``False``
 
+Command /RMG/Output/Germanium/StoreSinglePrecisionPosition
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use float32 (instead of float64) for position output.
+
+* **Parameter**: ``value``
+    * **Parameter type**: ``b``
+    * **Omittable**: ``False``
+
+Command /RMG/Output/Germanium/StoreSinglePrecisionEnergy
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use float32 (instead of float64) for energy output.
+
+* **Parameter**: ``value``
+    * **Parameter type**: ``b``
+    * **Omittable**: ``False``
+
 Command directory path : /RMG/Output/Vertex/
 --------------------------------------------
 
@@ -225,6 +245,8 @@ Commands for controlling output of primary vertices.
 * **Commands**:
     * *StorePrimaryParticleInformation*: ``Store information on primary particle details (not only vertex data).``
     * *SkipPrimaryVertexOutput*: ``Do not store vertex/primary particle data.``
+    * *StoreSinglePrecisionPosition*: ``Use float32 (instead of float64) for position output.``
+    * *StoreSinglePrecisionEnergy*: ``Use float32 (instead of float64) for energy output.``
 
 Command /RMG/Output/Vertex/StorePrimaryParticleInformation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -244,6 +266,24 @@ Do not store vertex/primary particle data.
     * **Parameter type**: ``b``
     * **Omittable**: ``False``
 
+Command /RMG/Output/Vertex/StoreSinglePrecisionPosition
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use float32 (instead of float64) for position output.
+
+* **Parameter**: ``value``
+    * **Parameter type**: ``b``
+    * **Omittable**: ``False``
+
+Command /RMG/Output/Vertex/StoreSinglePrecisionEnergy
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use float32 (instead of float64) for energy output.
+
+* **Parameter**: ``value``
+    * **Parameter type**: ``b``
+    * **Omittable**: ``False``
+
 Command directory path : /RMG/Output/Scintillator/
 --------------------------------------------------
 
@@ -253,6 +293,8 @@ Commands for controlling output from hits in scintillator detectors.
     * *SetEdepCutLow*: ``Set a lower energy cut that has to be met for this event to be stored.``
     * *SetEdepCutHigh*: ``Set an upper energy cut that has to be met for this event to be stored.``
     * *AddDetectorForEdepThreshold*: ``Take this detector into account for the filtering by /EdepThreshold.``
+    * *StoreSinglePrecisionPosition*: ``Use float32 (instead of float64) for position output.``
+    * *StoreSinglePrecisionEnergy*: ``Use float32 (instead of float64) for energy output.``
 
 Command /RMG/Output/Scintillator/SetEdepCutLow
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -289,6 +331,24 @@ Take this detector into account for the filtering by /EdepThreshold.
 
 * **Parameter**: ``det_uid``
     * **Parameter type**: ``i``
+    * **Omittable**: ``False``
+
+Command /RMG/Output/Scintillator/StoreSinglePrecisionPosition
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use float32 (instead of float64) for position output.
+
+* **Parameter**: ``value``
+    * **Parameter type**: ``b``
+    * **Omittable**: ``False``
+
+Command /RMG/Output/Scintillator/StoreSinglePrecisionEnergy
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use float32 (instead of float64) for energy output.
+
+* **Parameter**: ``value``
+    * **Parameter type**: ``b``
     * **Omittable**: ``False``
 
 Command directory path : /RMG/Output/IsotopeFilter/

--- a/include/RMGGermaniumOutputScheme.hh
+++ b/include/RMGGermaniumOutputScheme.hh
@@ -58,6 +58,9 @@ class RMGGermaniumOutputScheme : public RMGVOutputScheme {
     std::set<int> fEdepCutDetectors;
 
     bool fDiscardPhotonsIfNoGermaniumEdep = false;
+
+    bool fStoreSinglePrecisionEnergy = false;
+    bool fStoreSinglePrecisionPosition = false;
 };
 
 #endif

--- a/include/RMGScintillatorOutputScheme.hh
+++ b/include/RMGScintillatorOutputScheme.hh
@@ -54,6 +54,9 @@ class RMGScintillatorOutputScheme : public RMGVOutputScheme {
     double fEdepCutLow = -1;
     double fEdepCutHigh = -1;
     std::set<int> fEdepCutDetectors;
+
+    bool fStoreSinglePrecisionEnergy = false;
+    bool fStoreSinglePrecisionPosition = false;
 };
 
 #endif

--- a/include/RMGVOutputScheme.hh
+++ b/include/RMGVOutputScheme.hh
@@ -62,6 +62,17 @@ class RMGVOutputScheme {
       throw new std::logic_error("GetNtuplenameFlat not implemented");
     }
 
+    inline void CreateNtupleFOrDColumn(G4AnalysisManager* ana_man, int nt, std::string name,
+        bool use_float) {
+      if (use_float) ana_man->CreateNtupleFColumn(nt, name);
+      else ana_man->CreateNtupleDColumn(nt, name);
+    }
+    inline void FillNtupleFOrDColumn(G4AnalysisManager* ana_man, int nt, int col, double val,
+        bool use_float) {
+      if (use_float) ana_man->FillNtupleFColumn(nt, col, val);
+      else ana_man->FillNtupleDColumn(nt, col, val);
+    }
+
     bool fNtuplePerDetector = true;
 };
 

--- a/include/RMGVertexOutputScheme.hh
+++ b/include/RMGVertexOutputScheme.hh
@@ -48,6 +48,8 @@ class RMGVertexOutputScheme : public RMGVOutputScheme {
     void DefineCommands();
 
     bool fStorePrimaryParticleInformation = false;
+    bool fStoreSinglePrecisionEnergy = false;
+    bool fStoreSinglePrecisionPosition = false;
     bool fSkipPrimaryVertexOutput = false;
 };
 

--- a/src/RMGGermaniumOutputScheme.cc
+++ b/src/RMGGermaniumOutputScheme.cc
@@ -66,9 +66,9 @@ void RMGGermaniumOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) {
     ana_man->CreateNtupleIColumn(id, "particle");
     ana_man->CreateNtupleDColumn(id, "edep_in_keV");
     ana_man->CreateNtupleDColumn(id, "time_in_ns");
-    ana_man->CreateNtupleDColumn(id, "xloc_in_m");
-    ana_man->CreateNtupleDColumn(id, "yloc_in_m");
-    ana_man->CreateNtupleDColumn(id, "zloc_in_m");
+    ana_man->CreateNtupleFColumn(id, "xloc_in_m");
+    ana_man->CreateNtupleFColumn(id, "yloc_in_m");
+    ana_man->CreateNtupleFColumn(id, "zloc_in_m");
 
     ana_man->FinishNtuple(id);
   }
@@ -152,9 +152,9 @@ void RMGGermaniumOutputScheme::StoreEvent(const G4Event* event) {
       ana_man->FillNtupleIColumn(ntupleid, col_id++, hit->particle_type);
       ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->energy_deposition / u::keV);
       ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->global_time / u::ns);
-      ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->global_position.getX() / u::m);
-      ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->global_position.getY() / u::m);
-      ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->global_position.getZ() / u::m);
+      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position.getX() / u::m);
+      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position.getY() / u::m);
+      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position.getZ() / u::m);
 
       // NOTE: must be called here for hit-oriented output
       ana_man->AddNtupleRow(ntupleid);

--- a/src/RMGGermaniumOutputScheme.cc
+++ b/src/RMGGermaniumOutputScheme.cc
@@ -64,7 +64,7 @@ void RMGGermaniumOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) {
     ana_man->CreateNtupleIColumn(id, "evtid");
     if (!fNtuplePerDetector) { ana_man->CreateNtupleIColumn(id, "det_uid"); }
     ana_man->CreateNtupleIColumn(id, "particle");
-    ana_man->CreateNtupleDColumn(id, "edep_in_keV");
+    ana_man->CreateNtupleFColumn(id, "edep_in_keV");
     ana_man->CreateNtupleDColumn(id, "time_in_ns");
     ana_man->CreateNtupleFColumn(id, "xloc_in_m");
     ana_man->CreateNtupleFColumn(id, "yloc_in_m");
@@ -150,7 +150,7 @@ void RMGGermaniumOutputScheme::StoreEvent(const G4Event* event) {
         ana_man->FillNtupleIColumn(ntupleid, col_id++, hit->detector_uid);
       }
       ana_man->FillNtupleIColumn(ntupleid, col_id++, hit->particle_type);
-      ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->energy_deposition / u::keV);
+      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->energy_deposition / u::keV);
       ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->global_time / u::ns);
       ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position.getX() / u::m);
       ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position.getY() / u::m);

--- a/src/RMGGermaniumOutputScheme.cc
+++ b/src/RMGGermaniumOutputScheme.cc
@@ -64,11 +64,11 @@ void RMGGermaniumOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) {
     ana_man->CreateNtupleIColumn(id, "evtid");
     if (!fNtuplePerDetector) { ana_man->CreateNtupleIColumn(id, "det_uid"); }
     ana_man->CreateNtupleIColumn(id, "particle");
-    ana_man->CreateNtupleFColumn(id, "edep_in_keV");
+    CreateNtupleFOrDColumn(ana_man, id, "edep_in_keV", fStoreSinglePrecisionEnergy);
     ana_man->CreateNtupleDColumn(id, "time_in_ns");
-    ana_man->CreateNtupleFColumn(id, "xloc_in_m");
-    ana_man->CreateNtupleFColumn(id, "yloc_in_m");
-    ana_man->CreateNtupleFColumn(id, "zloc_in_m");
+    CreateNtupleFOrDColumn(ana_man, id, "xloc_in_m", fStoreSinglePrecisionPosition);
+    CreateNtupleFOrDColumn(ana_man, id, "yloc_in_m", fStoreSinglePrecisionPosition);
+    CreateNtupleFOrDColumn(ana_man, id, "zloc_in_m", fStoreSinglePrecisionPosition);
 
     ana_man->FinishNtuple(id);
   }
@@ -150,11 +150,15 @@ void RMGGermaniumOutputScheme::StoreEvent(const G4Event* event) {
         ana_man->FillNtupleIColumn(ntupleid, col_id++, hit->detector_uid);
       }
       ana_man->FillNtupleIColumn(ntupleid, col_id++, hit->particle_type);
-      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->energy_deposition / u::keV);
+      FillNtupleFOrDColumn(ana_man, ntupleid, col_id++, hit->energy_deposition / u::keV,
+          fStoreSinglePrecisionEnergy);
       ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->global_time / u::ns);
-      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position.getX() / u::m);
-      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position.getY() / u::m);
-      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position.getZ() / u::m);
+      FillNtupleFOrDColumn(ana_man, ntupleid, col_id++, hit->global_position.getX() / u::m,
+          fStoreSinglePrecisionPosition);
+      FillNtupleFOrDColumn(ana_man, ntupleid, col_id++, hit->global_position.getY() / u::m,
+          fStoreSinglePrecisionPosition);
+      FillNtupleFOrDColumn(ana_man, ntupleid, col_id++, hit->global_position.getZ() / u::m,
+          fStoreSinglePrecisionPosition);
 
       // NOTE: must be called here for hit-oriented output
       ana_man->AddNtupleRow(ntupleid);
@@ -213,6 +217,14 @@ void RMGGermaniumOutputScheme::DefineCommands() {
                    "detectors occurred in the same event.")
       .SetGuidance("note: If another output scheme also requests the photons to be discarded, the "
                    "germanium edep filter does not force the photons to be simulated.")
+      .SetStates(G4State_Idle);
+
+  fMessenger->DeclareProperty("StoreSinglePrecisionPosition", fStoreSinglePrecisionPosition)
+      .SetGuidance("Use float32 (instead of float64) for position output.")
+      .SetStates(G4State_Idle);
+
+  fMessenger->DeclareProperty("StoreSinglePrecisionEnergy", fStoreSinglePrecisionEnergy)
+      .SetGuidance("Use float32 (instead of float64) for energy output.")
       .SetStates(G4State_Idle);
 }
 

--- a/src/RMGScintillatorOutputScheme.cc
+++ b/src/RMGScintillatorOutputScheme.cc
@@ -65,14 +65,14 @@ void RMGScintillatorOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) 
     ana_man->CreateNtupleIColumn(id, "particle");
     ana_man->CreateNtupleDColumn(id, "edep_in_keV");
     ana_man->CreateNtupleDColumn(id, "time_in_ns");
-    ana_man->CreateNtupleDColumn(id, "xloc_pre_in_m");
-    ana_man->CreateNtupleDColumn(id, "yloc_pre_in_m");
-    ana_man->CreateNtupleDColumn(id, "zloc_pre_in_m");
-    ana_man->CreateNtupleDColumn(id, "xloc_post_in_m");
-    ana_man->CreateNtupleDColumn(id, "yloc_post_in_m");
-    ana_man->CreateNtupleDColumn(id, "zloc_post_in_m");
-    ana_man->CreateNtupleDColumn(id, "v_pre_in_m\\ns");
-    ana_man->CreateNtupleDColumn(id, "v_post_in_m\\ns");
+    ana_man->CreateNtupleFColumn(id, "xloc_pre_in_m");
+    ana_man->CreateNtupleFColumn(id, "yloc_pre_in_m");
+    ana_man->CreateNtupleFColumn(id, "zloc_pre_in_m");
+    ana_man->CreateNtupleFColumn(id, "xloc_post_in_m");
+    ana_man->CreateNtupleFColumn(id, "yloc_post_in_m");
+    ana_man->CreateNtupleFColumn(id, "zloc_post_in_m");
+    ana_man->CreateNtupleFColumn(id, "v_pre_in_m\\ns");
+    ana_man->CreateNtupleFColumn(id, "v_post_in_m\\ns");
 
     ana_man->FinishNtuple(id);
   }
@@ -156,14 +156,14 @@ void RMGScintillatorOutputScheme::StoreEvent(const G4Event* event) {
       ana_man->FillNtupleIColumn(ntupleid, col_id++, hit->particle_type);
       ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->energy_deposition / u::keV);
       ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->global_time / u::ns);
-      ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->global_position_pre.getX() / u::m);
-      ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->global_position_pre.getY() / u::m);
-      ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->global_position_pre.getZ() / u::m);
-      ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->global_position_post.getX() / u::m);
-      ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->global_position_post.getY() / u::m);
-      ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->global_position_post.getZ() / u::m);
-      ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->velocity_pre / u::m * u::ns);
-      ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->velocity_post / u::m * u::ns);
+      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position_pre.getX() / u::m);
+      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position_pre.getY() / u::m);
+      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position_pre.getZ() / u::m);
+      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position_post.getX() / u::m);
+      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position_post.getY() / u::m);
+      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position_post.getZ() / u::m);
+      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->velocity_pre / u::m * u::ns);
+      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->velocity_post / u::m * u::ns);
 
       // NOTE: must be called here for hit-oriented output
       ana_man->AddNtupleRow(ntupleid);

--- a/src/RMGScintillatorOutputScheme.cc
+++ b/src/RMGScintillatorOutputScheme.cc
@@ -63,7 +63,7 @@ void RMGScintillatorOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) 
     ana_man->CreateNtupleIColumn(id, "evtid");
     if (!fNtuplePerDetector) { ana_man->CreateNtupleIColumn(id, "det_uid"); }
     ana_man->CreateNtupleIColumn(id, "particle");
-    ana_man->CreateNtupleDColumn(id, "edep_in_keV");
+    ana_man->CreateNtupleFColumn(id, "edep_in_keV");
     ana_man->CreateNtupleDColumn(id, "time_in_ns");
     ana_man->CreateNtupleFColumn(id, "xloc_pre_in_m");
     ana_man->CreateNtupleFColumn(id, "yloc_pre_in_m");
@@ -154,7 +154,7 @@ void RMGScintillatorOutputScheme::StoreEvent(const G4Event* event) {
         ana_man->FillNtupleIColumn(ntupleid, col_id++, hit->detector_uid);
       }
       ana_man->FillNtupleIColumn(ntupleid, col_id++, hit->particle_type);
-      ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->energy_deposition / u::keV);
+      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->energy_deposition / u::keV);
       ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->global_time / u::ns);
       ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position_pre.getX() / u::m);
       ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position_pre.getY() / u::m);

--- a/src/RMGScintillatorOutputScheme.cc
+++ b/src/RMGScintillatorOutputScheme.cc
@@ -63,16 +63,16 @@ void RMGScintillatorOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) 
     ana_man->CreateNtupleIColumn(id, "evtid");
     if (!fNtuplePerDetector) { ana_man->CreateNtupleIColumn(id, "det_uid"); }
     ana_man->CreateNtupleIColumn(id, "particle");
-    ana_man->CreateNtupleFColumn(id, "edep_in_keV");
+    CreateNtupleFOrDColumn(ana_man, id, "edep_in_keV", fStoreSinglePrecisionEnergy);
     ana_man->CreateNtupleDColumn(id, "time_in_ns");
-    ana_man->CreateNtupleFColumn(id, "xloc_pre_in_m");
-    ana_man->CreateNtupleFColumn(id, "yloc_pre_in_m");
-    ana_man->CreateNtupleFColumn(id, "zloc_pre_in_m");
-    ana_man->CreateNtupleFColumn(id, "xloc_post_in_m");
-    ana_man->CreateNtupleFColumn(id, "yloc_post_in_m");
-    ana_man->CreateNtupleFColumn(id, "zloc_post_in_m");
-    ana_man->CreateNtupleFColumn(id, "v_pre_in_m\\ns");
-    ana_man->CreateNtupleFColumn(id, "v_post_in_m\\ns");
+    CreateNtupleFOrDColumn(ana_man, id, "xloc_pre_in_m", fStoreSinglePrecisionPosition);
+    CreateNtupleFOrDColumn(ana_man, id, "yloc_pre_in_m", fStoreSinglePrecisionPosition);
+    CreateNtupleFOrDColumn(ana_man, id, "zloc_pre_in_m", fStoreSinglePrecisionPosition);
+    CreateNtupleFOrDColumn(ana_man, id, "xloc_post_in_m", fStoreSinglePrecisionPosition);
+    CreateNtupleFOrDColumn(ana_man, id, "yloc_post_in_m", fStoreSinglePrecisionPosition);
+    CreateNtupleFOrDColumn(ana_man, id, "zloc_post_in_m", fStoreSinglePrecisionPosition);
+    CreateNtupleFOrDColumn(ana_man, id, "v_pre_in_m\\ns", fStoreSinglePrecisionPosition);
+    CreateNtupleFOrDColumn(ana_man, id, "v_post_in_m\\ns", fStoreSinglePrecisionPosition);
 
     ana_man->FinishNtuple(id);
   }
@@ -154,16 +154,25 @@ void RMGScintillatorOutputScheme::StoreEvent(const G4Event* event) {
         ana_man->FillNtupleIColumn(ntupleid, col_id++, hit->detector_uid);
       }
       ana_man->FillNtupleIColumn(ntupleid, col_id++, hit->particle_type);
-      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->energy_deposition / u::keV);
+      FillNtupleFOrDColumn(ana_man, ntupleid, col_id++, hit->energy_deposition / u::keV,
+          fStoreSinglePrecisionEnergy);
       ana_man->FillNtupleDColumn(ntupleid, col_id++, hit->global_time / u::ns);
-      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position_pre.getX() / u::m);
-      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position_pre.getY() / u::m);
-      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position_pre.getZ() / u::m);
-      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position_post.getX() / u::m);
-      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position_post.getY() / u::m);
-      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->global_position_post.getZ() / u::m);
-      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->velocity_pre / u::m * u::ns);
-      ana_man->FillNtupleFColumn(ntupleid, col_id++, hit->velocity_post / u::m * u::ns);
+      FillNtupleFOrDColumn(ana_man, ntupleid, col_id++, hit->global_position_pre.getX() / u::m,
+          fStoreSinglePrecisionPosition);
+      FillNtupleFOrDColumn(ana_man, ntupleid, col_id++, hit->global_position_pre.getY() / u::m,
+          fStoreSinglePrecisionPosition);
+      FillNtupleFOrDColumn(ana_man, ntupleid, col_id++, hit->global_position_pre.getZ() / u::m,
+          fStoreSinglePrecisionPosition);
+      FillNtupleFOrDColumn(ana_man, ntupleid, col_id++, hit->global_position_post.getX() / u::m,
+          fStoreSinglePrecisionPosition);
+      FillNtupleFOrDColumn(ana_man, ntupleid, col_id++, hit->global_position_post.getY() / u::m,
+          fStoreSinglePrecisionPosition);
+      FillNtupleFOrDColumn(ana_man, ntupleid, col_id++, hit->global_position_post.getZ() / u::m,
+          fStoreSinglePrecisionPosition);
+      FillNtupleFOrDColumn(ana_man, ntupleid, col_id++, hit->velocity_pre / u::m * u::ns,
+          fStoreSinglePrecisionPosition);
+      FillNtupleFOrDColumn(ana_man, ntupleid, col_id++, hit->velocity_post / u::m * u::ns,
+          fStoreSinglePrecisionPosition);
 
       // NOTE: must be called here for hit-oriented output
       ana_man->AddNtupleRow(ntupleid);
@@ -192,6 +201,14 @@ void RMGScintillatorOutputScheme::DefineCommands() {
       ->DeclareMethod("AddDetectorForEdepThreshold", &RMGScintillatorOutputScheme::AddEdepCutDetector)
       .SetGuidance("Take this detector into account for the filtering by /EdepThreshold.")
       .SetParameterName("det_uid", false)
+      .SetStates(G4State_Idle);
+
+  fMessenger->DeclareProperty("StoreSinglePrecisionPosition", fStoreSinglePrecisionPosition)
+      .SetGuidance("Use float32 (instead of float64) for position output.")
+      .SetStates(G4State_Idle);
+
+  fMessenger->DeclareProperty("StoreSinglePrecisionEnergy", fStoreSinglePrecisionEnergy)
+      .SetGuidance("Use float32 (instead of float64) for energy output.")
       .SetStates(G4State_Idle);
 }
 

--- a/src/RMGVertexOutputScheme.cc
+++ b/src/RMGVertexOutputScheme.cc
@@ -34,9 +34,9 @@ void RMGVertexOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) {
 
   ana_man->CreateNtupleIColumn(vid, "evtid");
   ana_man->CreateNtupleDColumn(vid, "time_in_ns");
-  ana_man->CreateNtupleDColumn(vid, "xloc_in_m");
-  ana_man->CreateNtupleDColumn(vid, "yloc_in_m");
-  ana_man->CreateNtupleDColumn(vid, "zloc_in_m");
+  ana_man->CreateNtupleFColumn(vid, "xloc_in_m");
+  ana_man->CreateNtupleFColumn(vid, "yloc_in_m");
+  ana_man->CreateNtupleFColumn(vid, "zloc_in_m");
   ana_man->CreateNtupleIColumn(vid, "n_part");
 
   ana_man->FinishNtuple(vid);
@@ -77,9 +77,9 @@ void RMGVertexOutputScheme::StoreEvent(const G4Event* event) {
       int vcol_id = 0;
       ana_man->FillNtupleIColumn(vntupleid, vcol_id++, event->GetEventID());
       ana_man->FillNtupleDColumn(vntupleid, vcol_id++, primary_vertex->GetT0() / u::ns);
-      ana_man->FillNtupleDColumn(vntupleid, vcol_id++, primary_vertex->GetX0() / u::m);
-      ana_man->FillNtupleDColumn(vntupleid, vcol_id++, primary_vertex->GetY0() / u::m);
-      ana_man->FillNtupleDColumn(vntupleid, vcol_id++, primary_vertex->GetZ0() / u::m);
+      ana_man->FillNtupleFColumn(vntupleid, vcol_id++, primary_vertex->GetX0() / u::m);
+      ana_man->FillNtupleFColumn(vntupleid, vcol_id++, primary_vertex->GetY0() / u::m);
+      ana_man->FillNtupleFColumn(vntupleid, vcol_id++, primary_vertex->GetZ0() / u::m);
       ana_man->FillNtupleIColumn(vntupleid, vcol_id++, n_primaries);
 
       // NOTE: must be called here for hit-oriented output

--- a/src/RMGVertexOutputScheme.cc
+++ b/src/RMGVertexOutputScheme.cc
@@ -48,10 +48,10 @@ void RMGVertexOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) {
     ana_man->CreateNtupleIColumn(pid, "evtid");
     ana_man->CreateNtupleIColumn(pid, "vertexid");
     ana_man->CreateNtupleIColumn(pid, "particle");
-    ana_man->CreateNtupleDColumn(pid, "px_in_MeV");
-    ana_man->CreateNtupleDColumn(pid, "py_in_MeV");
-    ana_man->CreateNtupleDColumn(pid, "pz_in_MeV");
-    ana_man->CreateNtupleDColumn(pid, "ekin_in_MeV");
+    ana_man->CreateNtupleFColumn(pid, "px_in_MeV");
+    ana_man->CreateNtupleFColumn(pid, "py_in_MeV");
+    ana_man->CreateNtupleFColumn(pid, "pz_in_MeV");
+    ana_man->CreateNtupleFColumn(pid, "ekin_in_MeV");
 
     ana_man->FinishNtuple(pid);
   }
@@ -93,10 +93,10 @@ void RMGVertexOutputScheme::StoreEvent(const G4Event* event) {
           ana_man->FillNtupleIColumn(pntupleid, pcol_id++, event->GetEventID());
           ana_man->FillNtupleIColumn(pntupleid, pcol_id++, j);
           ana_man->FillNtupleIColumn(pntupleid, pcol_id++, primary->GetPDGcode());
-          ana_man->FillNtupleDColumn(pntupleid, pcol_id++, primary->GetMomentum().getX() / u::MeV);
-          ana_man->FillNtupleDColumn(pntupleid, pcol_id++, primary->GetMomentum().getY() / u::MeV);
-          ana_man->FillNtupleDColumn(pntupleid, pcol_id++, primary->GetMomentum().getZ() / u::MeV);
-          ana_man->FillNtupleDColumn(pntupleid, pcol_id++, primary->GetKineticEnergy() / u::MeV);
+          ana_man->FillNtupleFColumn(pntupleid, pcol_id++, primary->GetMomentum().getX() / u::MeV);
+          ana_man->FillNtupleFColumn(pntupleid, pcol_id++, primary->GetMomentum().getY() / u::MeV);
+          ana_man->FillNtupleFColumn(pntupleid, pcol_id++, primary->GetMomentum().getZ() / u::MeV);
+          ana_man->FillNtupleFColumn(pntupleid, pcol_id++, primary->GetKineticEnergy() / u::MeV);
 
           // NOTE: must be called here for hit-oriented output
           ana_man->AddNtupleRow(pntupleid);

--- a/src/RMGVertexOutputScheme.cc
+++ b/src/RMGVertexOutputScheme.cc
@@ -34,9 +34,9 @@ void RMGVertexOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) {
 
   ana_man->CreateNtupleIColumn(vid, "evtid");
   ana_man->CreateNtupleDColumn(vid, "time_in_ns");
-  ana_man->CreateNtupleFColumn(vid, "xloc_in_m");
-  ana_man->CreateNtupleFColumn(vid, "yloc_in_m");
-  ana_man->CreateNtupleFColumn(vid, "zloc_in_m");
+  CreateNtupleFOrDColumn(ana_man, vid, "xloc_in_m", fStoreSinglePrecisionPosition);
+  CreateNtupleFOrDColumn(ana_man, vid, "yloc_in_m", fStoreSinglePrecisionPosition);
+  CreateNtupleFOrDColumn(ana_man, vid, "zloc_in_m", fStoreSinglePrecisionPosition);
   ana_man->CreateNtupleIColumn(vid, "n_part");
 
   ana_man->FinishNtuple(vid);
@@ -48,10 +48,10 @@ void RMGVertexOutputScheme::AssignOutputNames(G4AnalysisManager* ana_man) {
     ana_man->CreateNtupleIColumn(pid, "evtid");
     ana_man->CreateNtupleIColumn(pid, "vertexid");
     ana_man->CreateNtupleIColumn(pid, "particle");
-    ana_man->CreateNtupleFColumn(pid, "px_in_MeV");
-    ana_man->CreateNtupleFColumn(pid, "py_in_MeV");
-    ana_man->CreateNtupleFColumn(pid, "pz_in_MeV");
-    ana_man->CreateNtupleFColumn(pid, "ekin_in_MeV");
+    CreateNtupleFOrDColumn(ana_man, pid, "px_in_MeV", fStoreSinglePrecisionEnergy);
+    CreateNtupleFOrDColumn(ana_man, pid, "py_in_MeV", fStoreSinglePrecisionEnergy);
+    CreateNtupleFOrDColumn(ana_man, pid, "pz_in_MeV", fStoreSinglePrecisionEnergy);
+    CreateNtupleFOrDColumn(ana_man, pid, "ekin_in_MeV", fStoreSinglePrecisionEnergy);
 
     ana_man->FinishNtuple(pid);
   }
@@ -77,9 +77,12 @@ void RMGVertexOutputScheme::StoreEvent(const G4Event* event) {
       int vcol_id = 0;
       ana_man->FillNtupleIColumn(vntupleid, vcol_id++, event->GetEventID());
       ana_man->FillNtupleDColumn(vntupleid, vcol_id++, primary_vertex->GetT0() / u::ns);
-      ana_man->FillNtupleFColumn(vntupleid, vcol_id++, primary_vertex->GetX0() / u::m);
-      ana_man->FillNtupleFColumn(vntupleid, vcol_id++, primary_vertex->GetY0() / u::m);
-      ana_man->FillNtupleFColumn(vntupleid, vcol_id++, primary_vertex->GetZ0() / u::m);
+      FillNtupleFOrDColumn(ana_man, vntupleid, vcol_id++, primary_vertex->GetX0() / u::m,
+          fStoreSinglePrecisionPosition);
+      FillNtupleFOrDColumn(ana_man, vntupleid, vcol_id++, primary_vertex->GetY0() / u::m,
+          fStoreSinglePrecisionPosition);
+      FillNtupleFOrDColumn(ana_man, vntupleid, vcol_id++, primary_vertex->GetZ0() / u::m,
+          fStoreSinglePrecisionPosition);
       ana_man->FillNtupleIColumn(vntupleid, vcol_id++, n_primaries);
 
       // NOTE: must be called here for hit-oriented output
@@ -93,10 +96,14 @@ void RMGVertexOutputScheme::StoreEvent(const G4Event* event) {
           ana_man->FillNtupleIColumn(pntupleid, pcol_id++, event->GetEventID());
           ana_man->FillNtupleIColumn(pntupleid, pcol_id++, j);
           ana_man->FillNtupleIColumn(pntupleid, pcol_id++, primary->GetPDGcode());
-          ana_man->FillNtupleFColumn(pntupleid, pcol_id++, primary->GetMomentum().getX() / u::MeV);
-          ana_man->FillNtupleFColumn(pntupleid, pcol_id++, primary->GetMomentum().getY() / u::MeV);
-          ana_man->FillNtupleFColumn(pntupleid, pcol_id++, primary->GetMomentum().getZ() / u::MeV);
-          ana_man->FillNtupleFColumn(pntupleid, pcol_id++, primary->GetKineticEnergy() / u::MeV);
+          FillNtupleFOrDColumn(ana_man, pntupleid, pcol_id++,
+              primary->GetMomentum().getX() / u::MeV, fStoreSinglePrecisionEnergy);
+          FillNtupleFOrDColumn(ana_man, pntupleid, pcol_id++,
+              primary->GetMomentum().getY() / u::MeV, fStoreSinglePrecisionEnergy);
+          FillNtupleFOrDColumn(ana_man, pntupleid, pcol_id++,
+              primary->GetMomentum().getZ() / u::MeV, fStoreSinglePrecisionEnergy);
+          FillNtupleFOrDColumn(ana_man, pntupleid, pcol_id++, primary->GetKineticEnergy() / u::MeV,
+              fStoreSinglePrecisionEnergy);
 
           // NOTE: must be called here for hit-oriented output
           ana_man->AddNtupleRow(pntupleid);
@@ -117,6 +124,14 @@ void RMGVertexOutputScheme::DefineCommands() {
 
   fMessenger->DeclareProperty("SkipPrimaryVertexOutput", fSkipPrimaryVertexOutput)
       .SetGuidance("Do not store vertex/primary particle data.")
+      .SetStates(G4State_Idle);
+
+  fMessenger->DeclareProperty("StoreSinglePrecisionPosition", fStoreSinglePrecisionPosition)
+      .SetGuidance("Use float32 (instead of float64) for position output.")
+      .SetStates(G4State_Idle);
+
+  fMessenger->DeclareProperty("StoreSinglePrecisionEnergy", fStoreSinglePrecisionEnergy)
+      .SetGuidance("Use float32 (instead of float64) for energy output.")
       .SetStates(G4State_Idle);
 }
 


### PR DESCRIPTION
Different simulations will have different needs (i.e. energy depositions in scintillators might not be that well localized than HPGe hits), so make it configurable per output scheme.

But it still feels ugly to have that many options....