### PR TITLE
Only allow /RMG/Processes/Stepping/DaughterNucleusMaxLifetime in idle state

### DIFF
--- a/src/RMGSteppingAction.cc
+++ b/src/RMGSteppingAction.cc
@@ -81,7 +81,7 @@ void RMGSteppingAction::DefineCommands() {
       .SetGuidance("Set to -1 to disable this feature.")
       .SetParameterName("max_lifetime", false)
       .SetDefaultValue("-1")
-      .SetStates(G4State_PreInit);
+      .SetStates(G4State_Idle);
 }
 
 


### PR DESCRIPTION
* it is safe to use in idle state, too
* it is not registered yet in pre-init state in MT mode
* remove it from pre-init state to make macros behave consistently between MT/serial modes

**this breaks all macros that used this option until now.. :-(** but fixing is simple (just moving the command after `/run/initialize`)

---
other options to fix these incosistencies:
* move the command to the physics messenger and read from the physics instance in the stepping action (might be slower?)
* initialize _all_ (user) actions also on master, including Stepping-, Stacking-, TrackingActions... Currently we only have Run- and GeneratorActions on the master