### PR TITLE
Adjust examples to the new detector handling

### DIFF
--- a/examples/02-hpge/main.cc
+++ b/examples/02-hpge/main.cc
@@ -8,10 +8,10 @@ int main(int argc, char** argv) {
   RMGManager manager("02-hpge", argc, argv);
   manager.SetUserInit(new HPGeTestStand());
 
-  manager.GetDetectorConstruction()->RegisterDetector(RMGHardware::kGermanium, "HPGe1", 0);
-  manager.GetDetectorConstruction()->RegisterDetector(RMGHardware::kGermanium, "HPGe2", 1);
-  manager.GetDetectorConstruction()->RegisterDetector(RMGHardware::kGermanium, "HPGe3", 2);
-  manager.GetDetectorConstruction()->RegisterDetector(RMGHardware::kGermanium, "HPGe4", 3);
+  manager.GetDetectorConstruction()->RegisterDetector(kGermanium, "HPGe1", 0);
+  manager.GetDetectorConstruction()->RegisterDetector(kGermanium, "HPGe2", 1);
+  manager.GetDetectorConstruction()->RegisterDetector(kGermanium, "HPGe3", 2);
+  manager.GetDetectorConstruction()->RegisterDetector(kGermanium, "HPGe4", 3);
 
   std::string macro;
   if (argc == 2) macro = argv[1];

--- a/examples/03-optics/main.cc
+++ b/examples/03-optics/main.cc
@@ -8,8 +8,8 @@ int main(int argc, char** argv) {
 
   RMGManager manager("03-optics", argc, argv);
   manager.GetDetectorConstruction()->IncludeGDMLFile("gdml/geometry.gdml");
-  manager.GetDetectorConstruction()->RegisterDetector(RMGHardware::kOptical, "Detector1", 0);
-  manager.GetDetectorConstruction()->RegisterDetector(RMGHardware::kOptical, "Detector2", 1);
+  manager.GetDetectorConstruction()->RegisterDetector(kOptical, "Detector1", 0);
+  manager.GetDetectorConstruction()->RegisterDetector(kOptical, "Detector2", 1);
 
   std::string macro = argc > 1 ? argv[1] : "";
   if (!macro.empty()) manager.IncludeMacroFile(macro);

--- a/examples/04-cosmogenics/main.cc
+++ b/examples/04-cosmogenics/main.cc
@@ -10,10 +10,10 @@ int main(int argc, char** argv) {
   RMGManager manager("04-surface-cosmogenic", argc, argv);
   manager.SetUserInit(new HPGeTestStand());
 
-  manager.GetDetectorConstruction()->RegisterDetector(RMGHardware::kGermanium, "HPGe1", 0);
-  manager.GetDetectorConstruction()->RegisterDetector(RMGHardware::kGermanium, "HPGe2", 1);
-  manager.GetDetectorConstruction()->RegisterDetector(RMGHardware::kGermanium, "HPGe3", 2);
-  manager.GetDetectorConstruction()->RegisterDetector(RMGHardware::kGermanium, "HPGe4", 3);
+  manager.GetDetectorConstruction()->RegisterDetector(kGermanium, "HPGe1", 0);
+  manager.GetDetectorConstruction()->RegisterDetector(kGermanium, "HPGe2", 1);
+  manager.GetDetectorConstruction()->RegisterDetector(kGermanium, "HPGe3", 2);
+  manager.GetDetectorConstruction()->RegisterDetector(kGermanium, "HPGe4", 3);
 
   std::string macro = argc > 1 ? argv[1] : "";
   if (!macro.empty()) manager.IncludeMacroFile(macro);

--- a/examples/05-MUSUN/main.cc
+++ b/examples/05-MUSUN/main.cc
@@ -11,10 +11,10 @@ int main(int argc, char** argv) {
   manager.SetUserInit(new HPGeTestStand());
   manager.SetNumberOfThreads(2);
   manager.EnablePersistency();
-  manager.GetDetectorConstruction()->RegisterDetector(RMGHardware::kGermanium, "HPGe1", 0);
-  manager.GetDetectorConstruction()->RegisterDetector(RMGHardware::kGermanium, "HPGe2", 1);
-  manager.GetDetectorConstruction()->RegisterDetector(RMGHardware::kGermanium, "HPGe3", 2);
-  manager.GetDetectorConstruction()->RegisterDetector(RMGHardware::kGermanium, "HPGe4", 3);
+  manager.GetDetectorConstruction()->RegisterDetector(kGermanium, "HPGe1", 0);
+  manager.GetDetectorConstruction()->RegisterDetector(kGermanium, "HPGe2", 1);
+  manager.GetDetectorConstruction()->RegisterDetector(kGermanium, "HPGe3", 2);
+  manager.GetDetectorConstruction()->RegisterDetector(kGermanium, "HPGe4", 3);
 
   std::string macro = argc > 1 ? argv[1] : "";
   if (!macro.empty()) manager.IncludeMacroFile(macro);

--- a/examples/06-NeutronCapture/main.cc
+++ b/examples/06-NeutronCapture/main.cc
@@ -15,10 +15,10 @@ int main(int argc, char** argv) {
   user_init->AddOptionalOutputScheme<IsotopeOutputScheme>("IsotopeOutputScheme");
 
   // Need at least 1 active detector, otherwise persistency not enabled (even if manually setting it)
-  manager.GetDetectorConstruction()->RegisterDetector(RMGHardware::kGermanium, "HPGe1", 0);
-  // manager.GetDetectorConstruction()->RegisterDetector(RMGHardware::kGermanium, "HPGe2", 1);
-  // manager.GetDetectorConstruction()->RegisterDetector(RMGHardware::kGermanium, "HPGe3", 2);
-  // manager.GetDetectorConstruction()->RegisterDetector(RMGHardware::kGermanium, "HPGe4", 3);
+  manager.GetDetectorConstruction()->RegisterDetector(kGermanium, "HPGe1", 0);
+  // manager.GetDetectorConstruction()->RegisterDetector(kGermanium, "HPGe2", 1);
+  // manager.GetDetectorConstruction()->RegisterDetector(kGermanium, "HPGe3", 2);
+  // manager.GetDetectorConstruction()->RegisterDetector(kGermanium, "HPGe4", 3);
 
   std::string macro = argc > 1 ? argv[1] : "";
   if (!macro.empty()) manager.IncludeMacroFile(macro);


### PR DESCRIPTION
The recent updates that moved the 
```c++
    enum DetectorType {
      kGermanium,
      kOptical,
      kScintillator,
    };
```
Out of `RMGHardware` broke the examples and the custom written c++ code, as the enum is now no longer part of the `RMGHardware` class. This went past the tests, as there is no extra compiled code in the tests.

I am not sure if the rest of the way the registration should be handled is still the same, but this works. Compile tested but did not check the output.