### PR TITLE
reset decay times by default; add option for global time warning

### DIFF
--- a/docs/rmg-commands.md
+++ b/docs/rmg-commands.md
@@ -516,6 +516,7 @@ Commands for controlling physics processes
 
 * `DaughterNucleusMaxLifetime` – Determines which unstable daughter nuclei will be killed, if they are at rest, depending on their lifetime.
 * `ResetInitialDecayTime` – If the initial step is a radioactive decay, reset the global time of all its secondary tracks to 0.
+* `LargeGlobalTimeUncertaintyWarning` – Warn if the global times of tracks get too large to provide the requested time uncertainty.
 
 ### `/RMG/Processes/Stepping/DaughterNucleusMaxLifetime`
 
@@ -542,7 +543,21 @@ If the initial step is a radioactive decay, reset the global time of all its sec
 * **Parameter** – `value`
   * **Parameter type** – `b`
   * **Omittable** – `False`
-  * **Default value** – `false`
+  * **Default value** – `true`
+
+### `/RMG/Processes/Stepping/LargeGlobalTimeUncertaintyWarning`
+
+Warn if the global times of tracks get too large to provide the requested time uncertainty.
+
+* **Parameter** – `value`
+  * **Parameter type** – `d`
+  * **Omittable** – `False`
+  * **Default value** – `1`
+* **Parameter** – `Unit`
+  * **Parameter type** – `s`
+  * **Omittable** – `True`
+  * **Default value** – `us`
+  * **Candidates** – `s ms us ns ps min h d y second millisecond microsecond nanosecond picosecond minute hour day year`
 
 ## `/RMG/Geometry/`
 

--- a/include/RMGTrackingAction.hh
+++ b/include/RMGTrackingAction.hh
@@ -43,10 +43,13 @@ class RMGTrackingAction : public G4UserTrackingAction {
   private:
 
     RMGRunAction* fRunAction = nullptr;
-    bool fResetInitialDecayTime = false;
+    bool fResetInitialDecayTime = true;
     bool fHadLongTimeWarning = false;
+    double fMaxRepresentableGlobalTime = -1;
 
     bool ResetInitialDecayTime(const G4Track*);
+
+    void SetLongGlobalTimeUncertaintyWarning(double);
 
     std::unique_ptr<G4GenericMessenger> fMessenger;
     void DefineCommands();


### PR DESCRIPTION
fixes the remaining open issues in #135 