### PR TITLE
Dockerfile: use "stable" remage-base tag by default (i.e. Geant4 11.2 at the moment)

### DIFF
--- a/.dockerhub/Dockerfile
+++ b/.dockerhub/Dockerfile
@@ -1,4 +1,4 @@
-ARG REMAGE_BASE_FLAVOR="latest"
+ARG REMAGE_BASE_FLAVOR="stable"
 
 FROM gipert/remage-base:$REMAGE_BASE_FLAVOR
 


### PR DESCRIPTION
We might have to re-think this strategy in the future