### PR TITLE
Setup dummy X server for CI tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,11 +23,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # guideline: only test on latest patch releases (and maybe previous one)
         container_version:
         - G4.11.3
         - G4.11.2
-        - G4.11.1
-        - G4.11.0
         - slim
 
     container: docker://gipert/remage-base:${{ matrix.container_version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,10 +33,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Install pip dependencies for tests
-      # TODO: replace with a better way to manage test dependencies.
-      run: |
-        pip3 install --user --upgrade legend-pydataobj scipy
+
     - name: Build project
       run: |
         mkdir build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
 
   test_on_linux:
-    name: Test on Linux containers (Ubuntu LTS)
+    name: Test on remage image
     runs-on: ubuntu-latest
 
     strategy:
@@ -59,8 +59,8 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: test-output
-        # artifacts must have a ".output" extension
-        path: build/tests/**/*.output.*
+        # artifacts must have a ".output*" extension
+        path: build/tests/**/*.output*.*
 
     - name: Run minimal test suite
       if: ${{ matrix.container_version == 'slim' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,16 @@ jobs:
         DISPLAY: :99
       run: |
         cd build
-        ctest --output-on-failure --label-exclude 'vis'
+        ctest --output-on-failure
+
+    - name: Upload test suite outputs to GitHub
+      if: ${{ matrix.container_version != 'slim' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-output
+        # artifacts must have a ".output" extension
+        path: build/tests/**/*.output.*
+
     - name: Run minimal test suite
       if: ${{ matrix.container_version == 'slim' }}
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,16 +41,26 @@ jobs:
         cmake -DRMG_BUILD_EXAMPLES=1 ..
         make
         make install
+
+    - name: Setup and start xvfb (enables Geant4 visualization)
+      run: |
+        Xvfb :99 -screen 0 1920x1080x24 &
+
     - name: Run full test suite
       if: ${{ matrix.container_version != 'slim' }}
+      env:
+        DISPLAY: :99
       run: |
         cd build
         ctest --output-on-failure --label-exclude 'vis'
     - name: Run minimal test suite
       if: ${{ matrix.container_version == 'slim' }}
+      env:
+        DISPLAY: :99
       run: |
         cd build
         ctest --output-on-failure --label-exclude 'extra|vis'
+
     - name: Compare checked-in doc dump with current result
       if: ${{ matrix.container_version != 'slim' }}
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
       if: ${{ matrix.container_version != 'slim' }}
       uses: actions/upload-artifact@v4
       with:
-        name: test-output
+        name: test-output-${{ matrix.container_version }}
         # artifacts must have a ".output*" extension
         path: build/tests/**/*.output*.*
 

--- a/tests/basics/macros/vis-2nbb.mac
+++ b/tests/basics/macros/vis-2nbb.mac
@@ -8,4 +8,4 @@
 
 /run/beamOn 100
 
-/vis/ogl/export vis-2nbb.pdf
+/vis/ogl/export vis-2nbb.output.pdf

--- a/tests/basics/macros/vis-co60.mac
+++ b/tests/basics/macros/vis-co60.mac
@@ -13,4 +13,4 @@
 
 /run/beamOn 100
 
-/vis/ogl/export vis-co60.pdf
+/vis/ogl/export vis-co60.output.pdf

--- a/tests/confinement/macros/_init.mac
+++ b/tests/confinement/macros/_init.mac
@@ -1,3 +1,3 @@
 /run/initialize
 
-/RMG/Manager/Logging/LogLevel debug
+/RMG/Manager/Logging/LogLevel summary

--- a/tests/confinement/macros/_vis.mac
+++ b/tests/confinement/macros/_vis.mac
@@ -1,6 +1,6 @@
 /run/initialize
 
-/RMG/Manager/Logging/LogLevel debug
+/RMG/Manager/Logging/LogLevel summary
 
 /vis/open OGL
 /vis/drawVolume

--- a/tests/confinement/macros/complex-volume.mac
+++ b/tests/confinement/macros/complex-volume.mac
@@ -15,4 +15,4 @@
 
 /run/beamOn 5000
 
-/control/alias export-fn complex-volume.pdf
+/control/alias export-fn complex-volume.output.pdf

--- a/tests/confinement/macros/geometrical-and-physical.mac
+++ b/tests/confinement/macros/geometrical-and-physical.mac
@@ -20,4 +20,4 @@
 
 /run/beamOn 2000
 
-/control/alias export-fn geometrical-and-physical.pdf
+/control/alias export-fn geometrical-and-physical.output.pdf

--- a/tests/confinement/macros/geometrical-or-physical.mac
+++ b/tests/confinement/macros/geometrical-or-physical.mac
@@ -21,4 +21,4 @@
 
 /run/beamOn 2000
 
-/control/alias export-fn geometrical-or-physical.pdf
+/control/alias export-fn geometrical-or-physical.output.pdf

--- a/tests/confinement/macros/geometrical.mac
+++ b/tests/confinement/macros/geometrical.mac
@@ -36,4 +36,4 @@
 
 /run/beamOn 5000
 
-/control/alias export-fn geometrical.pdf
+/control/alias export-fn geometrical.output.pdf

--- a/tests/confinement/macros/native-surface.mac
+++ b/tests/confinement/macros/native-surface.mac
@@ -13,4 +13,4 @@
 
 /run/beamOn 2000
 
-/control/alias export-fn native-surface.pdf
+/control/alias export-fn native-surface.output.pdf

--- a/tests/confinement/macros/native-volume.mac
+++ b/tests/confinement/macros/native-volume.mac
@@ -13,4 +13,4 @@
 
 /run/beamOn 2000
 
-/control/alias export-fn native-volume.pdf
+/control/alias export-fn native-volume.output.pdf


### PR DESCRIPTION
- tests/docs dependencies are already available in the base image (see recent changes to https://github.com/gipert/remage-docker)
- use Xvfb to start a dummy X server -> enables Geant4 visualization
- upload test output files matching pattern `*.output.*` to GitHub as artifacts