### PR TITLE
change IsInside check for UnionAll to act only on the selected solid not the full collection.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 project(
   remage
-  VERSION 0.5.0
+  VERSION 0.6.2
   DESCRIPTION "Simulation framework for HPGe-based experiments"
   LANGUAGES C CXX) # C is needed for Geant4's HDF5 support
 

--- a/include/RMGVertexConfinement.hh
+++ b/include/RMGVertexConfinement.hh
@@ -92,6 +92,7 @@ class RMGVertexConfinement : public RMGVVertexGenerator {
             bool cc = true);
         // NOTE: G4 volume/solid pointers should be fully owned by G4, avoid trying to delete them
         ~SampleableObject() = default;
+        [[nodiscard]] bool IsInside(const G4ThreeVector& vertex) const;
 
         G4VPhysicalVolume* physical_volume = nullptr;
         G4VSolid* sampling_solid = nullptr;

--- a/src/RMGVertexConfinement.cc
+++ b/src/RMGVertexConfinement.cc
@@ -107,14 +107,23 @@ const RMGVertexConfinement::SampleableObject& RMGVertexConfinement::SampleableOb
   return this->data.back();
 }
 
+bool RMGVertexConfinement::SampleableObject::IsInside(const G4ThreeVector& vertex) const {
+  auto navigator = G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking();
+
+  if (this->physical_volume) {
+    if (navigator->LocateGlobalPointAndSetup(vertex) == this->physical_volume) return true;
+  } else {
+    if (this->sampling_solid->Inside(this->rotation.inverse() * vertex - this->translation))
+      return true;
+  }
+
+  return false;
+}
+
 bool RMGVertexConfinement::SampleableObjectCollection::IsInside(const G4ThreeVector& vertex) const {
   auto navigator = G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking();
   for (const auto& o : data) {
-    if (o.physical_volume) {
-      if (navigator->LocateGlobalPointAndSetup(vertex) == o.physical_volume) return true;
-    } else {
-      if (o.sampling_solid->Inside(o.rotation.inverse() * vertex - o.translation)) return true;
-    }
+    if (o.IsInside(vertex)) return true;
   }
   return false;
 }
@@ -539,9 +548,6 @@ bool RMGVertexConfinement::ActualGenerateVertex(G4ThreeVector& vertex) {
       RMGLog::OutDev(RMGLog::debug,
           "Maximum attempts to find a good vertex: ", RMGVVertexGenerator::fMaxAttempts);
 
-      RMGVertexConfinement::SampleableObjectCollection selected_sources = {};
-      selected_sources.emplace_back(choice);
-
       while (calls++ < RMGVVertexGenerator::fMaxAttempts) {
         fTrials++;
 
@@ -549,7 +555,7 @@ bool RMGVertexConfinement::ActualGenerateVertex(G4ThreeVector& vertex) {
         if (choice.containment_check) {
           vertex = choice.translation +
                    choice.rotation * RMGGeneratorUtil::rand(choice.sampling_solid, fOnSurface);
-          while (!selected_sources.IsInside(vertex) and calls++ < RMGVVertexGenerator::fMaxAttempts) {
+          while (!choice.IsInside(vertex) and calls++ < RMGVVertexGenerator::fMaxAttempts) {
             fTrials++;
             vertex = choice.translation +
                      choice.rotation * RMGGeneratorUtil::rand(choice.sampling_solid, fOnSurface);
@@ -568,7 +574,7 @@ bool RMGVertexConfinement::ActualGenerateVertex(G4ThreeVector& vertex) {
           vertex = choice.translation +
                    choice.rotation * RMGGeneratorUtil::rand(choice.sampling_solid, fOnSurface);
           RMGLog::OutDev(RMGLog::debug, "Generated vertex: ", vertex / CLHEP::cm, " cm");
-          if (fForceContainmentCheck && !selected_sources.IsInside(vertex)) {
+          if (fForceContainmentCheck && !choice.IsInside(vertex)) {
             RMGLog::OutDev(RMGLog::error,
                 "Generated vertex not inside sampling volumes (forced containment check): ",
                 vertex / CLHEP::cm, " cm");

--- a/src/RMGVertexConfinement.cc
+++ b/src/RMGVertexConfinement.cc
@@ -539,13 +539,17 @@ bool RMGVertexConfinement::ActualGenerateVertex(G4ThreeVector& vertex) {
       RMGLog::OutDev(RMGLog::debug,
           "Maximum attempts to find a good vertex: ", RMGVVertexGenerator::fMaxAttempts);
 
+      RMGVertexConfinement::SampleableObjectCollection selected_sources = {};
+      selected_sources.emplace_back(choice);
+
       while (calls++ < RMGVVertexGenerator::fMaxAttempts) {
         fTrials++;
+
 
         if (choice.containment_check) {
           vertex = choice.translation +
                    choice.rotation * RMGGeneratorUtil::rand(choice.sampling_solid, fOnSurface);
-          while (!fPhysicalVolumes.IsInside(vertex) and calls++ < RMGVVertexGenerator::fMaxAttempts) {
+          while (!selected_sources.IsInside(vertex) and calls++ < RMGVVertexGenerator::fMaxAttempts) {
             fTrials++;
             vertex = choice.translation +
                      choice.rotation * RMGGeneratorUtil::rand(choice.sampling_solid, fOnSurface);
@@ -564,7 +568,7 @@ bool RMGVertexConfinement::ActualGenerateVertex(G4ThreeVector& vertex) {
           vertex = choice.translation +
                    choice.rotation * RMGGeneratorUtil::rand(choice.sampling_solid, fOnSurface);
           RMGLog::OutDev(RMGLog::debug, "Generated vertex: ", vertex / CLHEP::cm, " cm");
-          if (fForceContainmentCheck && !all_volumes.IsInside(vertex)) {
+          if (fForceContainmentCheck && !selected_sources.IsInside(vertex)) {
             RMGLog::OutDev(RMGLog::error,
                 "Generated vertex not inside sampling volumes (forced containment check): ",
                 vertex / CLHEP::cm, " cm");


### PR DESCRIPTION
Fixes #209 (at least for UnionAll), however, maybe we would like a cleaner solution than making a container with only 1 solid in it.
We also need to:
- [ ] include the tests of #209 as unit tests
- [ ] check + fix + test Intersections and subtractions.