### PR TITLE
Add vis label to all tests opening a GUI

### DIFF
--- a/tests/confinement/CMakeLists.txt
+++ b/tests/confinement/CMakeLists.txt
@@ -128,8 +128,16 @@ set(_surface_tests
 foreach(_test ${_surface_tests})
 
   add_test(NAME confinment-surface/${_test} COMMAND ./test-surface-sampler-methods ${_test})
-  set_tests_properties(confinment-surface/${_test} PROPERTIES LABELS extra FIXTURES_REQUIRED
-                                                              test-surface-sampler-methods-fixture)
+
+  if(_test MATCHES "test-points-.*")
+    set_tests_properties(
+      confinment-surface/${_test} PROPERTIES LABELS "extra;vis" FIXTURES_REQUIRED
+                                             test-surface-sampler-methods-fixture)
+  else()
+    set_tests_properties(
+      confinment-surface/${_test} PROPERTIES LABELS extra FIXTURES_REQUIRED
+                                             test-surface-sampler-methods-fixture)
+  endif()
 endforeach()
 
 # now run some simulations and test the outputs
@@ -159,7 +167,7 @@ foreach(det ${_solids})
                    gdml/simple-solids.gdml -w -l detail)
 
   set_tests_properties(
-    confinment-surface/${det}-vis PROPERTIES LABELS extra FIXTURES_REQUIRED
+    confinment-surface/${det}-vis PROPERTIES LABELS "extra;vis" FIXTURES_REQUIRED
                                              confine-surface-vis-macro-${det}-fixture)
 endforeach()
 


### PR DESCRIPTION
Some of the tests added did not have the "vis" label although they opened a GUI. When i run tests localy inside of the apptainer container that use the OGL GUI they brick my screen, which means i typically have to restart the computer, so I typically run `ctest -LE vis`. I am sure there is some way to fix my local issue, but i think also the labels should be applied correctly ;)