### PR TITLE
fix ASan warning with RMGVOutputScheme and optional output schemes

### DIFF
--- a/include/RMGVOutputScheme.hh
+++ b/include/RMGVOutputScheme.hh
@@ -34,6 +34,7 @@ class RMGVOutputScheme {
   public:
 
     RMGVOutputScheme() = default;
+    virtual ~RMGVOutputScheme() = default;
 
     // initialization.
     virtual inline void AssignOutputNames(G4AnalysisManager*) {}


### PR DESCRIPTION
This was found by running our test suite with ASan enabled.