### PR TITLE
clang-tidy: fix uninitialized variables and more

### DIFF
--- a/include/RMGGrabmayrGCReader.hh
+++ b/include/RMGGrabmayrGCReader.hh
@@ -27,6 +27,7 @@
 
 // Modified from WLGDPetersGammaCascadeReader originally contributed by Moritz Neuberger
 struct GammaCascadeLine {
+    GammaCascadeLine() = delete;
     G4int en;              // neutron energy [keV]
     G4int ex;              // excitation energy [keV]
     G4int m;               // multiplicity of gamma cascade

--- a/include/RMGPhysics.hh
+++ b/include/RMGPhysics.hh
@@ -98,9 +98,9 @@ class RMGPhysics : public G4VModularPhysicsList {
 
   private:
 
-    PhysicsRealm fPhysicsRealm;
-    StepCutStore fStepCuts;
-    StepCutStore fStepCutsSensitive;
+    PhysicsRealm fPhysicsRealm = PhysicsRealm::kDoubleBetaDecay;
+    StepCutStore fStepCuts = {};
+    StepCutStore fStepCutsSensitive = {};
     bool fConstructOptical = false;
     bool fUseOpticalCustomWLS = false;
     bool fUseThermalScattering = false;

--- a/include/RMGVOutputScheme.hh
+++ b/include/RMGVOutputScheme.hh
@@ -82,7 +82,8 @@ class RMGVOutputScheme {
     }
     inline void FillNtupleFOrDColumn(G4AnalysisManager* ana_man, int nt, int col, double val,
         bool use_float) {
-      if (use_float) ana_man->FillNtupleFColumn(nt, col, val);
+      if (use_float)
+        ana_man->FillNtupleFColumn(nt, col, val); // NOLINT(cppcoreguidelines-narrowing-conversions)
       else ana_man->FillNtupleDColumn(nt, col, val);
     }
 

--- a/include/RMGVertexConfinement.hh
+++ b/include/RMGVertexConfinement.hh
@@ -314,7 +314,7 @@ class RMGVertexConfinement : public RMGVVertexGenerator {
 
     // counters used for the current run.
     long fTrials = 0;
-    std::chrono::nanoseconds fVertexGenerationTime;
+    std::chrono::nanoseconds fVertexGenerationTime{};
 
     std::vector<std::unique_ptr<G4GenericMessenger>> fMessengers;
     void SetSamplingModeString(std::string mode);

--- a/src/RMGConvertLH5.cc
+++ b/src/RMGConvertLH5.cc
@@ -147,7 +147,7 @@ bool RMGConvertLH5::ConvertNTupleToTable(H5::Group& det_group) {
     LH5Log(RMGLog::error, ntuple_log_prefix, "invalid columns dataset");
     return false;
   }
-  uint32_t expected_column_count;
+  uint32_t expected_column_count = 0;
   dset_columns.read(&expected_column_count, dset_columns.getDataType());
 
   // read the column names into a buffer. This contains the full data with null bytes.
@@ -242,7 +242,7 @@ bool RMGConvertLH5::CheckGeantHeader(H5::Group& header_group) {
   if (!header_group.attrExists("data_schema_version")) return false;
   auto att_schema_version = header_group.openAttribute("data_schema_version");
   if (att_schema_version.getDataType() != H5::PredType::STD_I32LE) return false;
-  int32_t schema_version;
+  int32_t schema_version = 0;
   att_schema_version.read(att_schema_version.getDataType(), &schema_version);
   if (schema_version != 1) return false;
 

--- a/src/RMGGeneratorMUSUNCosmicMuons.cc
+++ b/src/RMGGeneratorMUSUNCosmicMuons.cc
@@ -66,7 +66,7 @@ void RMGGeneratorMUSUNCosmicMuons::PrepareCopy(G4String pathToFile) {
   std::istringstream iss(firstLine);
   std::vector<std::string> tokens(std::istream_iterator<std::string>{iss},
       std::istream_iterator<std::string>());
-  int numColumns = tokens.size();
+  size_t numColumns = tokens.size();
 
   // Define header template
   std::string header_template = "#class tools::wcsv::ntuple\n"

--- a/src/RMGGeneratorUtil.cc
+++ b/src/RMGGeneratorUtil.cc
@@ -59,9 +59,8 @@ G4ThreeVector RMGGeneratorUtil::rand(const G4Box* box, bool on_surface) {
     std::array<double, 3> A = {4 * dx * dy, 4 * dx * dz, 4 * dy * dz};
 
     auto face = _g4rand() * std::accumulate(A.begin(), A.end(), 0);
-    ;
     auto face_sign = _g4rand() <= 0.5 ? -1 : 1;
-    double x, y, z;
+    double x = NAN, y = NAN, z = NAN;
 
     if (face <= A[0]) {
       x = dx * (2 * _g4rand() - 1);

--- a/src/RMGGrabmayrGCReader.cc
+++ b/src/RMGGrabmayrGCReader.cc
@@ -54,11 +54,11 @@ GammaCascadeLine RMGGrabmayrGCReader::GetNextEntry(G4int z, G4int a) {
                                  std::string::npos)); // This could be outsourced to SetStartLocation
 
   // parse line and return as struct
-  GammaCascadeLine gamma_cascade;
+  GammaCascadeLine gamma_cascade{};
   std::istringstream iss(line);
   iss >> gamma_cascade.en >> gamma_cascade.ex >> gamma_cascade.m >> gamma_cascade.em;
   gamma_cascade.eg.reserve(gamma_cascade.m);
-  int eg_value;
+  int eg_value = 0;
   for (int i = 0; i < gamma_cascade.m; i++) {
     if (!(iss >> eg_value)) {
       RMGLog::Out(RMGLog::fatal, "Failed to read gamma energy from file. Exit!");

--- a/src/RMGNeutronCaptureProcess.cc
+++ b/src/RMGNeutronCaptureProcess.cc
@@ -52,8 +52,8 @@ G4VParticleChange* RMGNeutronCaptureProcess::PostStepDoIt(const G4Track& aTrack,
   auto CascadeReader = RMGGrabmayrGCReader::GetInstance();
 
   G4int nSec = ProposedResult->GetNumberOfSecondaries();
-  G4int z;
-  G4int a;
+  G4int z = -1;
+  G4int a = -1;
   G4bool IsApplicable = false;
   // Search through the proposed secondaries for our Isotopes of interest
   if (nSec > 0) {

--- a/src/RMGPhysics.cc
+++ b/src/RMGPhysics.cc
@@ -182,7 +182,7 @@ void RMGPhysics::ConstructProcess() {
   // G4EmExtraPhysics does not propagate the verbose level...
   auto synch_proc = G4ProcessTable::GetProcessTable()->FindProcesses("SynRad");
   for (size_t i = 0; i < synch_proc->size(); i++) {
-    (*synch_proc)[i]->SetVerboseLevel(G4VModularPhysicsList::verboseLevel);
+    (*synch_proc)[(int)i]->SetVerboseLevel(G4VModularPhysicsList::verboseLevel);
   }
 
   if (fConstructOptical) this->ConstructOptical();

--- a/src/RMGSteppingAction.cc
+++ b/src/RMGSteppingAction.cc
@@ -39,7 +39,7 @@ void RMGSteppingAction::UserSteppingAction(const G4Step* step) {
 
     if (particle_type == "nucleus" && track->GetParentID() > 0 &&
         track->GetKineticEnergy() < 0.1 * CLHEP::keV) {
-      auto ion = static_cast<G4Ions*>(track->GetDefinition());
+      auto ion = dynamic_cast<G4Ions*>(track->GetDefinition());
       double lifetime = ion->GetPDGLifeTime();
       double excitation = ion->GetExcitationEnergy();
 

--- a/src/remage-from-lh5.cc
+++ b/src/remage-from-lh5.cc
@@ -25,8 +25,8 @@ namespace fs = std::filesystem;
 #include "CLI11/CLI11.hpp"
 
 int main(int argc, char** argv) {
-  bool verbosity;
-  bool dry_run;
+  bool verbosity = false;
+  bool dry_run = false;
   std::vector<std::string> file_names;
   std::string ntuple_group_name = "stp";
 

--- a/src/remage-to-lh5.cc
+++ b/src/remage-to-lh5.cc
@@ -25,8 +25,8 @@ namespace fs = std::filesystem;
 #include "CLI11/CLI11.hpp"
 
 int main(int argc, char** argv) {
-  bool verbosity;
-  bool dry_run;
+  bool verbosity = false;
+  bool dry_run = false;
   std::vector<std::string> file_names;
   std::string ntuple_group_name = "stp";
 

--- a/src/remage.cc
+++ b/src/remage.cc
@@ -50,7 +50,7 @@ int main(int argc, char** argv) {
 
   CLI::App app{"remage: simulation framework for germanium experiments"};
 
-  int verbosity;
+  int verbosity = 0;
   bool quiet = false;
   bool version = false;
   bool version_rich = false;
@@ -108,7 +108,7 @@ int main(int argc, char** argv) {
   if (quiet) RMGLog::SetLogLevel(RMGLog::warning);
 
   // handle signal to abort the current run.
-  struct sigaction sig;
+  struct sigaction sig{};
   sig.sa_handler = &signal_handler;
   sigemptyset(&sig.sa_mask);
   sig.sa_flags = 0;


### PR DESCRIPTION
in a follow-up I will actually enable the corresponsing checks