### PR TITLE
remove implicit conversion to numpy arrays in ge-distance test

### DIFF
--- a/tests/distances/test_ge_distance.py
+++ b/tests/distances/test_ge_distance.py
@@ -42,13 +42,21 @@ det_map = {
 
 steps = lh5.read_as("stp/germanium", outfile, "ak")
 # Transform the coordinates to the local detector frame
-uint = np.array(np.full_like(steps.time, -1), dtype=int)
-xlocal = np.array(1000 * steps.xloc)
-ylocal = np.array(1000 * steps.yloc)
-zlocal = np.array(1000 * steps.zloc)
+uint = np.array(np.full_like(steps.time.to_numpy(), -1), dtype=int)
+xlocal = 1000 * steps.xloc.to_numpy()
+ylocal = 1000 * steps.yloc.to_numpy()
+zlocal = 1000 * steps.zloc.to_numpy()
 
 positions = np.array(
-    np.transpose(np.vstack([steps.xloc * 1000, steps.yloc * 1000, steps.zloc * 1000]))
+    np.transpose(
+        np.vstack(
+            [
+                steps.xloc.to_numpy() * 1000,
+                steps.yloc.to_numpy() * 1000,
+                steps.zloc.to_numpy() * 1000,
+            ]
+        )
+    )
 )
 for det in det_map:
     local_positions = copy.copy(positions)


### PR DESCRIPTION
Question: Should i also increase the tolerance? As it seems that in rare cases this test might fail. It is not 100% certain that it was due to the tolerance, but i guess that is most likely. Currently 1e-9 mm means 1 picometer accuracy, that we do not need.