### PR TITLE
Fix Python wrapper install

### DIFF
--- a/.dockerhub/Dockerfile
+++ b/.dockerhub/Dockerfile
@@ -33,6 +33,7 @@ RUN mkdir -p src build /opt/remage && \
     else \
         ctest --output-on-failure --label-exclude 'vis'; \
     fi && \
+    cd .. && \
     rm -rf build src
 
 ENV PATH="/opt/remage/bin:$PATH" \

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-mkdir build
-cd build || exit 1
-cmake ..
-make
-make install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,9 +145,4 @@ jobs:
           cd build
           ctest --output-on-failure --label-exclude 'extra|vis'
 
-      - name: Minimally test installed executable
-        run: |
-          rm -rf build
-          PATH="$PWD/local/bin:$PATH" DYLD_LIBRARY_PATH="$PWD/local/lib:$DYLD_LIBRARY_PATH" remage --version
-
 # vim: expandtab tabstop=2 shiftwidth=2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,7 +136,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DRMG_BUILD_EXAMPLES=1 -DBUILD_TESTING=ON -DRMG_BUILD_DOCS=OFF ..
+          cmake -DCMAKE_INSTALL_PREFIX=../local -DRMG_BUILD_EXAMPLES=1 -DBUILD_TESTING=ON -DRMG_BUILD_DOCS=OFF ..
           make
           make install
 
@@ -148,6 +148,6 @@ jobs:
       - name: Minimally test installed executable
         run: |
           rm -rf build
-          PATH="/usr/local/bin:$PATH" LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH" remage --version
+          PATH="$PWD/local/bin:$PATH" DYLD_LIBRARY_PATH="$PWD/local/lib:$DYLD_LIBRARY_PATH" remage --version
 
 # vim: expandtab tabstop=2 shiftwidth=2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,11 @@ jobs:
           make remage-doc-dump
           diff ../docs/rmg-commands.md ../docs/rmg-commands.md.bak
 
+      - name: Minimally test installed executable
+        run: |
+          rm -rf build
+          PATH="/usr/local/bin:$PATH" LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH" remage --version
+
   test_on_mac:
     name: Test on macOS
     runs-on: macos-latest
@@ -129,9 +134,9 @@ jobs:
 
       - name: Build project
         run: |
-          mkdir build .local
+          mkdir build
           cd build
-          cmake -DCMAKE_INSTALL_PREFIX=../local -DRMG_BUILD_EXAMPLES=1 -DBUILD_TESTING=ON -DRMG_BUILD_DOCS=OFF ..
+          cmake -DRMG_BUILD_EXAMPLES=1 -DBUILD_TESTING=ON -DRMG_BUILD_DOCS=OFF ..
           make
           make install
 
@@ -139,5 +144,10 @@ jobs:
         run: |
           cd build
           ctest --output-on-failure --label-exclude 'extra|vis'
+
+      - name: Minimally test installed executable
+        run: |
+          rm -rf build
+          PATH="/usr/local/bin:$PATH" LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH" remage --version
 
 # vim: expandtab tabstop=2 shiftwidth=2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ endif()
 
 # let's now look for python, needed for build preparation, the python wrapper and tests
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
-message(STATUS "Found Python interpreter: ${Python3_EXECUTABLE}")
 
 execute_process(
   COMMAND "${Python3_EXECUTABLE}" -m venv --help

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ endif()
 
 # let's now look for python, needed for build preparation, the python wrapper and tests
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
+message(STATUS "Found Python interpreter: ${Python3_EXECUTABLE}")
 
 execute_process(
   COMMAND "${Python3_EXECUTABLE}" -m venv --help

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -35,7 +35,7 @@ add_custom_command(
   OUTPUT ${VENV_DIR}/bin/uv
   COMMAND ${Python3_EXECUTABLE} -m venv ${VENV_DIR}
   COMMAND ${VENV_DIR}/bin/python -m pip -q install --no-warn-script-location --upgrade pip
-  COMMAND ${VENV_DIR}/bin/python -m pip -q install --no-warn-script-location uv
+  COMMAND ${VENV_DIR}/bin/python -m pip -q install --no-warn-script-location --upgrade uv
   COMMENT "Configuring Python virtual environment")
 
 add_custom_target(python-virtualenv DEPENDS ${VENV_DIR}/bin/uv)
@@ -56,12 +56,11 @@ else()
   set(_pkg_install ${CMAKE_SOURCE_DIR})
 endif()
 
+# now we want to use the cpp_config for the build area
 add_custom_command(
   OUTPUT ${VENV_DIR}/bin/remage
-  COMMAND
-    cp
-    ${CMAKE_CURRENT_BINARY_DIR}/cpp_config.build.py # now we want to use the cpp_config for the build area
-    ${CMAKE_CURRENT_SOURCE_DIR}/remage/cpp_config.py
+  COMMAND cp ${CMAKE_CURRENT_BINARY_DIR}/cpp_config.build.py
+          ${CMAKE_CURRENT_SOURCE_DIR}/remage/cpp_config.py
   COMMAND ${VENV_DIR}/bin/python -m uv pip -q install --reinstall ${_pkg_install}
   COMMAND printf -- "-- Installed python wrapper "
   COMMAND bash -c '${VENV_DIR}/bin/python -m uv pip show remage 2>&1 | grep Version'
@@ -75,20 +74,22 @@ set_target_properties(remage-cli PROPERTIES PYEXE_PATH ${VENV_DIR}/bin/remage)
 
 # install section
 
-# install the package into the install prefix with the existing uv installation
+# install the package into the install prefix together with a virtualenv
+# in this way remage should always run isolated in its environment.
+# we want to use the cpp_config for the install area
 add_custom_command(
   OUTPUT ${CMAKE_INSTALL_PREFIX}/bin/remage
-  COMMAND
-    cp
-    ${CMAKE_CURRENT_BINARY_DIR}/cpp_config.install.py # now we want to use the cpp_config for the install area
-    ${CMAKE_CURRENT_SOURCE_DIR}/remage/cpp_config.py
-  COMMAND ${VENV_DIR}/bin/python -m uv -q pip install --reinstall --prefix ${CMAKE_INSTALL_PREFIX}
-          ${CMAKE_SOURCE_DIR})
-
-add_custom_target(
-  install-remage-cli
-  DEPENDS ${CMAKE_INSTALL_PREFIX}/bin/remage
+  COMMAND ${Python3_EXECUTABLE} -m venv ${CMAKE_INSTALL_PREFIX}
+  COMMAND ${CMAKE_INSTALL_PREFIX}/bin/python -m pip -q install --no-warn-script-location --upgrade
+          pip
+  COMMAND ${CMAKE_INSTALL_PREFIX}/bin/python -m pip -q install --no-warn-script-location --upgrade
+          uv
+  COMMAND cp ${CMAKE_CURRENT_BINARY_DIR}/cpp_config.install.py
+          ${CMAKE_CURRENT_SOURCE_DIR}/remage/cpp_config.py
+  COMMAND ${CMAKE_INSTALL_PREFIX}/bin/python -m uv -q pip install --reinstall ${CMAKE_SOURCE_DIR}
   COMMENT "Installing remage Python wrapper")
+
+add_custom_target(install-remage-cli DEPENDS ${CMAKE_INSTALL_PREFIX}/bin/remage)
 
 # hack the install process to also install the remage wrapper
 install(


### PR DESCRIPTION
I realized that the installed remage wrapper is completely borked: it is set to use the Python interpreter from the virtualenv in the build area. I didn't realize this because we exclusively test remage in the build area (bad idea).

- [x] fix removal of src/build dirs in Dockerfile
- [x] fix python wrapper installation by installing a virtualenv in the install area
- [x] test installed executable in CI
