### PR TITLE
support wrapper-only args and macro substitutions

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -3,8 +3,15 @@
 
 set(_r ${PROJECT_SOURCE_DIR})
 
-set(PYTHON_SOURCES ${_r}/cmake/cpp_config.py.in ${_r}/python/remage/__init__.py
-                   ${_r}/python/remage/cli.py ${_r}/python/remage/ipc.py ${_r}/pyproject.toml)
+# cmake-format: off
+set(PYTHON_SOURCES
+    ${_r}/pyproject.toml
+    ${_r}/cmake/cpp_config.py.in
+    ${_r}/python/remage/__init__.py
+    ${_r}/python/remage/cli.py
+    ${_r}/python/remage/ipc.py
+    ${_r}/python/remage/preproc.py)
+# cmake-format: on
 
 # get the output name of the remage-cli target (set in src/CMakeLists.txt)
 get_target_property(REMAGE_CPP_OUTPUT_NAME remage-cli-cpp OUTPUT_NAME)

--- a/python/remage/cli.py
+++ b/python/remage/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import contextlib
 import logging
 import os
@@ -8,20 +9,32 @@ import signal
 import subprocess
 import sys
 import threading
+from collections.abc import Sequence
 from pathlib import Path
 
 import colorlog
 
+from . import preproc
 from .cpp_config import REMAGE_CPP_EXE_PATH
 from .ipc import IpcResult, ipc_thread_fn
 
 log = logging.getLogger(__name__)
 
+LOG_LEVELS_RMG2PY = {
+    "debug": logging.DEBUG,
+    "detail": logging.INFO,
+    "summary": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+    "fatal": logging.CRITICAL,
+    "nothing": logging.CRITICAL,
+}
+
 
 def _run_remage_cpp(
-    args: list[str] | None = None,
+    args: Sequence[str] | None = None,
 ) -> tuple[int, signal.Signals, IpcResult]:
-    """run the remage-cpp executable and return the exit code as seen in bash."""
+    """Run the remage-cpp executable and return its exit code."""
 
     # open pipe for IPC C++ -> python.
     pipe_r, pipe_w = os.pipe()
@@ -109,7 +122,7 @@ def _setup_log() -> logging.Logger:
     return logger
 
 
-def _cleanup_tmp_files(ipc_info: IpcResult) -> None:
+def _cleanup_cpp_tmp_files(ipc_info: IpcResult) -> None:
     """Remove temporary files created by the C++ application, that might not have been cleaned up."""
     tmp_files = ipc_info.get("tmpfile")
     for tmp_file in tmp_files:
@@ -118,12 +131,137 @@ def _cleanup_tmp_files(ipc_info: IpcResult) -> None:
             p.unlink(missing_ok=True)
 
 
+def _parse_remage_args(
+    args: Sequence[str],
+) -> tuple[argparse.Namespace, argparse.Namespace, list[str]]:
+    # NOTE: duplicated in src/remage.cc
+    # NOTE: no need to duplicate cpp-only arguments
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        default=False,
+        help="""Print only warnings and errors (same as --log-level=warning)""",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        default=False,
+        help="""Increase program verbosity to maximum (same as --log-level=debug)""",
+    )
+    parser.add_argument(
+        "--version", action="store_true", help="""Print remage's version and exit"""
+    )
+    parser.add_argument(
+        "--version-rich",
+        action="store_true",
+        help="""Print versions of remage and its dependencies and exit""",
+    )
+    parser.add_argument(
+        "-l",
+        "--log-level",
+        choices=["debug", "detail", "summary", "warning", "error", "fatal", "nothing"],
+        default="summary",
+        help="""Set the logging level""",
+    )
+    parser.add_argument(
+        "-i",
+        "--interactive",
+        action="store_true",
+        help="""Open an interactive macro command prompt""",
+    )
+    parser.add_argument(
+        "-t",
+        "--threads",
+        help="""Set the number of threads used by remage""",
+        default=1,
+    )
+    parser.add_argument(
+        "-g",
+        "--gdml-files",
+        nargs="+",
+        help="""Supply one or more GDML files describing the experimental geometry""",
+    )
+    parser.add_argument("-o", "--output-file", help="""The output file name""")
+    parser.add_argument(
+        "-w",
+        "--overwrite",
+        action="store_true",
+        help="""Overwrite existing output files""",
+    )
+    parser.add_argument(
+        "macros",
+        nargs="*",
+        default=[],
+        help="""One or more remage/Geant4 macro command listings to execute""",
+    )
+
+    parser.add_argument(
+        "--substitute-in-macro",
+        "-s",
+        nargs="+",
+        default=None,
+        metavar="KEY=VAL",
+        help="key-value pairs (e.g., a=1 b=2 c=3)",
+    )
+
+    # parse them
+    return parser.parse_args(args)
+
+
 def remage_run(
-    args: list[str] | None = None, *, raise_error: bool = True
+    args: Sequence[str] | None = None, *, raise_error: bool = True
 ) -> tuple[int, IpcResult]:
+    """Execute remage.
+
+    Parameters
+    ----------
+    args
+        list of command line arguments. ``None`` is reserved for
+        non-python-console usage (i.e. used by the remage wrapper executable).
+    raise_error
+        raise an exception if the remage executable returns a non-null exit
+        code.
+    """
     logger = _setup_log()
 
+    # args=None can be passed to parser.parse_args() and it will use sys.argv,
+    # but here we want it to be not None because we want to pass it over to
+    # process_template_macros_in_args()
+    if args is None:
+        args = list(sys.argv[1:])
+
+    # pre-processing
+    # need to sniff the args sent to remage-cpp
+    parsed_args = _parse_remage_args(args)
+
+    # set log level of the python wrapper
+    # NOTE: same priority/logic as in src/remage.cc
+    log_level = parsed_args.log_level
+    if parsed_args.verbose:
+        log_level = "debug"
+    if parsed_args.quiet:
+        log_level = "warning"
+
+    logger.setLevel(LOG_LEVELS_RMG2PY[log_level])
+
+    # user requests variable substitutions in the macro
+    tmp_macros = None
+    if parsed_args.substitute_in_macro is not None and parsed_args.macros is not None:
+        tmp_macros = preproc.process_template_macros_in_args(
+            args, parsed_args.macros, parsed_args.substitute_in_macro
+        )
+
+    msg = f"post-processed remage args: {args}"
+    log.debug(msg)
+
+    # run remage-cpp
     ec, termsig, ipc_info = _run_remage_cpp(args)
+
     # print an error message for the termination signal, similar to what bash does.
     if termsig not in (None, signal.SIGINT, signal.SIGPIPE):
         log.error(
@@ -133,7 +271,7 @@ def remage_run(
         )
 
     # clean-up should run always, irrespective of exit code.
-    _cleanup_tmp_files(ipc_info)
+    _cleanup_cpp_tmp_files(ipc_info)
 
     if ec not in [0, 2]:
         # remage had an error (::fatal -> ec==134 (SIGABRT); ::error -> ec==1)
@@ -141,25 +279,20 @@ def remage_run(
         if raise_error:
             msg = "error while running remage-cpp"
             raise RuntimeError(msg)
+
         return ec, ipc_info
+
+    if tmp_macros is not None:
+        [Path(f).unlink() for f in tmp_macros]
 
     assert termsig is None  # now we should only have had a graceful exit.
 
-    # setup logging based on log level from C++.
+    # reset log level based on log level from C++ (in case it was modified via macro)
     log_level = ipc_info.get_single("loglevel", "summary")
-    levels_rmg_to_py = {
-        "debug": logging.DEBUG,
-        "detail": logging.INFO,
-        "summary": logging.INFO,
-        "warning": logging.WARNING,
-        "error": logging.ERROR,
-        "fatal": logging.CRITICAL,
-        "nothing": logging.CRITICAL,
-    }
-    logger.setLevel(levels_rmg_to_py[log_level])
+    logger.setLevel(LOG_LEVELS_RMG2PY[log_level])
 
     # TODO: further post-processing
-    _output_files = ipc_info.get("output")
+    # _output_files = ipc_info.get("output")
 
     return ec, ipc_info
 

--- a/python/remage/preproc.py
+++ b/python/remage/preproc.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import logging
+import string
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+def process_template_macro(macro_file: str | Path, mapping: Mapping[str, Any]) -> Path:
+    """Replace variables in a template macro.
+
+    Parameters
+    ----------
+    macro_file
+        path to template macro file.
+    mapping
+        `key -> value` mapping of variables and values to be substituted.
+    """
+    macro_file = Path(macro_file)
+
+    with macro_file.open() as f:
+        macro = string.Template(f.read())
+
+    try:
+        proc_macro = macro.substitute(mapping)
+    except KeyError as e:
+        msg = f"missing key '{e.args[0]}' in variable substitution dictionary"
+        raise KeyError(msg) from e
+    except ValueError as e:
+        msg = "invalid template macro format, please check the syntax"
+        raise RuntimeError(msg) from e
+
+    tmp_macro_file = tempfile.NamedTemporaryFile(  # noqa: SIM115
+        suffix=f"-{macro_file.name}", mode="w", delete=False
+    )
+    tmp_macro_file.write(proc_macro)
+    tmp_macro_file.close()
+
+    return Path(tmp_macro_file.name)
+
+
+def process_template_macros_in_args(
+    cpp_arg_list: Sequence[str],
+    template_macros: Sequence[str],
+    substitute_args: Sequence[str],
+) -> list[str]:
+    """Replace template macro paths with substituted macros in remage command line.
+
+    Parameters
+    ----------
+    cpp_arg_list
+        list of remage command line arguments.
+    template_macros
+        list of template macros present at the end of `cpp_arg_list`.
+    substitute_args
+        list of key-value variable substitutions (e.g. ``a=1``, ``b=2``, ...)
+
+    Warning
+    -------
+    This function modifies `cpp_arg_list` in place.
+    """
+    # parse substitutions dictionary
+    substitutions = {kv.split("=")[0]: kv.split("=")[1] for kv in substitute_args}
+
+    # make list of temporary macros with substitutions
+    proc_macros = [
+        str(process_template_macro(macro, substitutions)) for macro in template_macros
+    ]
+
+    # replace macros in the command line with these temporary files
+    # the macros are always the last args
+    cpp_arg_list[-len(template_macros) :] = proc_macros
+
+    return proc_macros

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -1,1 +1,25 @@
-add_test(NAME python/cli COMMAND "${REMAGE_PYEXE}" -q --help)
+file(
+  GLOB _file_list
+  RELATIVE ${PROJECT_SOURCE_DIR}
+  gdml/*.gdml macros/*.mac *.py)
+
+# copy them to the build area
+foreach(_file ${_file_list})
+  configure_file(${PROJECT_SOURCE_DIR}/${_file} ${PROJECT_BINARY_DIR}/${_file} COPYONLY)
+endforeach()
+
+# run all python tests with pytest
+add_test(NAME python/all COMMAND "${PYTHONPATH}" -m pytest -vvv)
+
+# run executable tests
+# cmake-format: off
+add_test(NAME python/cli
+    COMMAND "${REMAGE_PYEXE}"
+    --gdml-files gdml/geometry.gdml
+    --output-file output.lh5
+    --overwrite
+    --substitute-in-macro ENERGY=1000
+    --threads 1
+    --log-level summary
+    -- macros/run.mac)
+# cmake-format: on

--- a/tests/python/test_preproc.py
+++ b/tests/python/test_preproc.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from remage import preproc
+
+
+def test_macro_preproc(tmpdir):
+    tmp_macro = tmpdir / "macro_noproc.mac"
+
+    macro_lines = [
+        r"/RMG/Generator/PositionX ${XPOS}",
+        r"/RMG/Generator/PositionY $YPOS",
+        r"/RMG/Generator/PositionZ $$ZPOS",
+        r"/RMG/Generator/Select ${GENERATOR}",
+        r"/gps/particle e-",
+        r"/gps/ang/type iso",
+        r"/gps/energy $ENERGY keV",
+    ]
+
+    with tmp_macro.open("w") as f:
+        f.writelines(line + "\n" for line in macro_lines)
+
+    tmp_macro_preproc = preproc.process_template_macro(
+        tmp_macro,
+        {
+            "XPOS": 1,
+            "YPOS": 2,
+            "ZPOS": 3,
+            "ENERGY": 1111.11,
+            "GENERATOR": "GPS",
+        },
+    )
+
+    with tmp_macro_preproc.open() as f:
+        proc_macro_lines = [line.rstrip("\n") for line in f]
+
+    assert proc_macro_lines == [
+        r"/RMG/Generator/PositionX 1",
+        r"/RMG/Generator/PositionY 2",
+        r"/RMG/Generator/PositionZ $ZPOS",
+        r"/RMG/Generator/Select GPS",
+        r"/gps/particle e-",
+        r"/gps/ang/type iso",
+        r"/gps/energy 1111.11 keV",
+    ]
+
+
+def test_bad_macro_template(tmpdir):
+    tmp_macro = tmpdir / "macro_noproc.mac"
+
+    macro_lines = [
+        r"/RMG/Generator/PositionX ${XPOS}",
+        r"/RMG/Generator/PositionY $YPOS",
+    ]
+
+    with tmp_macro.open("w") as f:
+        f.writelines(line + "\n" for line in macro_lines)
+
+    with pytest.raises(KeyError):
+        preproc.process_template_macro(tmp_macro, {"XPOS": 1})
+
+    macro_lines = [
+        r"/RMG/Generator/PositionX $XPOS",
+        r"/RMG/Generator/PositionY $ ",
+    ]
+
+    with tmp_macro.open("w") as f:
+        f.writelines(line + "\n" for line in macro_lines)
+
+    with pytest.raises(RuntimeError):
+        preproc.process_template_macro(tmp_macro, {"XPOS": 1})
+
+
+def test_macro_hijacking(tmpdir):
+    tmp_macros = [f"{tmpdir}/macro{n}.mac" for n in range(3)]
+
+    macro_lines = [
+        r"/RMG/Generator/PositionX ${XPOS}",
+        r"/RMG/Generator/PositionY $YPOS",
+    ]
+
+    for _file in tmp_macros:
+        with Path(_file).open("w") as f:
+            f.writelines(line + "\n" for line in macro_lines)
+
+    args = ["-w", "--threads", "3", "--interactive", "--", *tmp_macros]
+
+    preproc.process_template_macros_in_args(args, tmp_macros, ["XPOS=1", "YPOS=2"])
+
+    assert args[: -len(tmp_macros)] == ["-w", "--threads", "3", "--interactive", "--"]
+    for i, m in enumerate(tmp_macros):
+        assert args[-len(tmp_macros) + i].endswith(Path(m).name)


### PR DESCRIPTION
We can now substitute variables in template macro files (e.g. `$ENERGY` -> `1000`) at runtime. This is going very helpful in the dataflow and for studying systematics.
```
remage --substitute-in-macro ENERGY=1000 -- macro.mac
```
where `macro.mac`:
```
/RMG/Geometry/RegisterDetector Germanium germanium 001

/run/initialize

/RMG/Generator/Confine Volume
/RMG/Generator/Confinement/Geometrical/AddSolid Sphere
/RMG/Generator/Confinement/Geometrical/Sphere/OuterRadius 1

/RMG/Generator/Confinement/Geometrical/CenterPositionX 0
/RMG/Generator/Confinement/Geometrical/CenterPositionY 0
/RMG/Generator/Confinement/Geometrical/CenterPositionZ 0

/RMG/Generator/Select GPS
/gps/particle e-
/gps/ang/type iso
/gps/energy $ENERGY keV

/run/beamOn 1000
```

I had to figure out how to support args parsing in the Python wrapper and forwarding to `remage-cpp`. I had to change quite some code, sorry.