### PR TITLE
use static library for libfmt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,8 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/fmtlib/fmt
   GIT_TAG 1239137) # 11.1.4
 FetchContent_MakeAvailable(fmt)
+# fmt is a static lib, make it linkable into libremage.
+set_target_properties(fmt PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
 # obtain CLI11
 FetchContent_Declare(

--- a/include/RMGLog.hh
+++ b/include/RMGLog.hh
@@ -30,9 +30,6 @@
 
 #include "globals.hh"
 
-#ifndef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY
-#endif
 #include "fmt/core.h"
 
 #define OutDev(loglevel, ...) RMGLog::Out(loglevel, "[", __PRETTY_FUNCTION__, "] ", __VA_ARGS__)


### PR DESCRIPTION
until now, the `#define` in `RMGLog.hh` was the only thing preventing lots of linker errors, as this - by chance - always was included before any other fmt use.

properly use the static library `libfmt.a` now, as we cannot suppress it being built anyway (this is a known limitation with fmt and FetchContent).