### PR TITLE
python: add find_remage module

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -1,0 +1,30 @@
+name: distribute
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: 3
+
+jobs:
+  dist:
+    name: Distribution build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: hynek/build-and-inspect-python-package@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,7 +123,9 @@ jobs:
       - name: Minimally test installed executable
         run: |
           rm -rf build
-          PATH="/usr/local/bin:$PATH" LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH" remage --version
+          export PATH="/usr/local/bin:$PATH"
+          export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
+          REMAGE_ASSERT_CPP_ORIGIN="config" remage --version
 
   test_on_mac:
     name: Test on macOS
@@ -174,7 +176,9 @@ jobs:
       - name: Minimally test installed executable
         run: |
           rm -rf build
-          PATH="$PWD/local/bin:$PATH" DYLD_LIBRARY_PATH="$PWD/local/lib:$CONDA_PREFIX/lib:$DYLD_LIBRARY_PATH" remage --version
+          export PATH="$PWD/local/bin:$PATH"
+          export DYLD_LIBRARY_PATH="$PWD/local/lib:$CONDA_PREFIX/lib:$DYLD_LIBRARY_PATH"
+          REMAGE_ASSERT_CPP_ORIGIN="config" remage --version
 
   deploy_validation_report:
     name: Deploy validation report to legend-exp.github.io/remage/validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,11 +78,14 @@ Changelog = "https://github.com/legend-exp/remage/releases"
 version.source = "vcs"
 build.hooks.vcs.version-file = "python/remage/_version.py"
 
+[tool.hatch.build.targets.sdist]
+ignore-vcs = true
+include = ["python/**/*"]
+exclude = ["python/CMakeLists.txt"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["python/remage"]
-
-[tool.hatch.build.targets.wheel.force-include]
-"python/remage/cpp_config.py" = "remage/cpp_config.py"
+ignore-vcs = true
 
 [tool.hatch.envs.default]
 features = ["test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ Changelog = "https://github.com/legend-exp/remage/releases"
 version.source = "vcs"
 build.hooks.vcs.version-file = "python/remage/_version.py"
 
+[tool.hatch.version.raw-options]
+dist_name = "remage"
+
 [tool.hatch.build.targets.sdist]
 ignore-vcs = true
 include = ["python/**/*"]

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -8,6 +8,7 @@ set(PYTHON_SOURCES
     ${_r}/pyproject.toml
     ${_r}/cmake/cpp_config.py.in
     ${_r}/python/remage/__init__.py
+    ${_r}/python/remage/find_remage.py
     ${_r}/python/remage/cli.py
     ${_r}/python/remage/ipc.py)
 # cmake-format: on
@@ -69,8 +70,9 @@ add_custom_command(
   COMMAND cp ${CMAKE_CURRENT_BINARY_DIR}/cpp_config.build.py
           ${CMAKE_CURRENT_SOURCE_DIR}/remage/cpp_config.py
   COMMAND ${VENV_DIR}/bin/python -m uv pip -q install --reinstall ${_pkg_install}
+  COMMAND rm ${CMAKE_CURRENT_SOURCE_DIR}/remage/cpp_config.py
   COMMAND printf -- "-- Installed python wrapper "
-  COMMAND bash -c '${VENV_DIR}/bin/python -m uv pip show remage 2>&1 | grep Version'
+  COMMAND sh -c '${VENV_DIR}/bin/python -m uv pip show remage 2>&1 | grep Version'
   DEPENDS python-virtualenv ${PYTHON_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/cpp_config.build.py
   COMMENT "Installing remage Python wrapper into the virtual environment")
 
@@ -106,6 +108,7 @@ add_custom_command(
           ${CMAKE_INSTALL_PREFIX}/share
   COMMAND mv ${CMAKE_INSTALL_PREFIX}/share/remage-*-py3-none-any.whl
           ${CMAKE_INSTALL_PREFIX}/share/remage-py3-none-any.whl
+  COMMAND rm ${CMAKE_CURRENT_SOURCE_DIR}/remage/cpp_config.py
   # we want to use the cpp_config for the install area
   DEPENDS ${PYTHON_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/cpp_config.install.py
   WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -69,7 +69,8 @@ add_custom_command(
   OUTPUT ${VENV_DIR}/bin/remage
   COMMAND cp ${CMAKE_CURRENT_BINARY_DIR}/cpp_config.build.py
           ${CMAKE_CURRENT_SOURCE_DIR}/remage/cpp_config.py
-  COMMAND ${VENV_DIR}/bin/python -m uv pip -q install --reinstall ${_pkg_install}
+  COMMAND SETUPTOOLS_SCM_PRETEND_VERSION_FOR_REMAGE=${RMG_GIT_VERSION_FULL} ${VENV_DIR}/bin/python
+          -m uv pip -q install --reinstall ${_pkg_install}
   COMMAND rm ${CMAKE_CURRENT_SOURCE_DIR}/remage/cpp_config.py
   COMMAND printf -- "-- Installed python wrapper "
   COMMAND sh -c '${VENV_DIR}/bin/python -m uv pip show remage 2>&1 | grep Version'
@@ -101,11 +102,14 @@ add_custom_command(
   # install our package into this venv
   COMMAND cp ${CMAKE_CURRENT_BINARY_DIR}/cpp_config.install.py
           ${CMAKE_CURRENT_SOURCE_DIR}/remage/cpp_config.py
-  COMMAND ${INSTALL_VENV_DIR}/bin/python -m uv -q pip install --reinstall ${CMAKE_SOURCE_DIR}
+  COMMAND SETUPTOOLS_SCM_PRETEND_VERSION_FOR_REMAGE=${RMG_GIT_VERSION_FULL}
+          ${INSTALL_VENV_DIR}/bin/python -m uv -q pip install --reinstall ${CMAKE_SOURCE_DIR}
   COMMAND ln -fs ${INSTALL_VENV_DIR}/bin/remage ${CMAKE_INSTALL_PREFIX}/bin/remage
   # create and install a user-installable wheel
-  COMMAND ${INSTALL_VENV_DIR}/bin/python -m uv build --wheel ${CMAKE_SOURCE_DIR} -o
-          ${CMAKE_INSTALL_PREFIX}/share
+  COMMAND
+    SETUPTOOLS_SCM_PRETEND_VERSION_FOR_REMAGE=${RMG_GIT_VERSION_FULL}
+    ${INSTALL_VENV_DIR}/bin/python -m uv build --wheel ${CMAKE_SOURCE_DIR} -o
+    ${CMAKE_INSTALL_PREFIX}/share
   COMMAND mv ${CMAKE_INSTALL_PREFIX}/share/remage-*-py3-none-any.whl
           ${CMAKE_INSTALL_PREFIX}/share/remage-py3-none-any.whl
   COMMAND rm ${CMAKE_CURRENT_SOURCE_DIR}/remage/cpp_config.py

--- a/python/remage/find_remage.py
+++ b/python/remage/find_remage.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+def _find_remage_from_config() -> Path | None:
+    try:
+        from .cpp_config import REMAGE_CPP_EXE_PATH
+
+        return Path(REMAGE_CPP_EXE_PATH), "config"
+    except ImportError:
+        return None
+
+
+def find_remage_cpp() -> Path:
+    """Find the remage executable, either by using the config stored into the package
+    at build-time or by using the system PATH."""
+
+    path = _find_remage_from_config()
+
+    if path is None:
+        path = shutil.which("remage-cpp")
+        path = (Path(path), "path") if path is not None else None
+
+    if path is None or not path[0].exists():
+        msg = (
+            f"remage-cpp executable '{path}' not found. Ensure to use the right python "
+            + "installation and/or set-up your PATH correctly."
+        )
+        raise RuntimeError(msg)
+
+    assert isinstance(path[0], Path)
+    # this is just for testing purposes, so that we can test on CI that our package is
+    # built correctly and uses the right discovery mode.
+    assert_origin = os.getenv("REMAGE_ASSERT_CPP_ORIGIN", "")
+    assert assert_origin == "" or path[1] == assert_origin
+
+    return path[0]


### PR DESCRIPTION
This should not change functionality when installed via cmake, but should allow to install the python package directly from the source tree, without using cmake.

This PR now makes the wrapper actually installable via pip/pypi (`pip install .` in the repository root, not in the python sub-directory). sdists and wheels are adjusted to be buildable in both ways and only contain the python code.

**note:** when trying this out, make sure that no `cpp_config.py` file exists in the folder when installing, as that would disable the new path-based discovery logic. This file should not be persistent in any case, after you ran `make` the first time.

see #317 