### PR TITLE
Allow surface sampling on volumes with daughters

### DIFF
--- a/src/RMGVertexConfinement.cc
+++ b/src/RMGVertexConfinement.cc
@@ -419,7 +419,7 @@ void RMGVertexConfinement::InitializePhysicalVolumes() {
         el.native_sample = false;
         if (fOnSurface)
           RMGLog::OutDev(RMGLog::warning,
-              "Surface sampling is on the mother volume for volumes with daughters.");
+              "Surface sampling is on the outside of the mother volume for volumes with daughters.");
 
       } else {
         RMGLog::OutDev(RMGLog::debug, "Has no daughters, no containment check needed");
@@ -432,7 +432,7 @@ void RMGVertexConfinement::InitializePhysicalVolumes() {
 
       if (log_vol->GetNoDaughters() > 0)
         RMGLog::OutDev(RMGLog::warning,
-            "Surface sampling is on the mother volume for volumes with daughters.");
+            "Surface sampling is on the outside of the mother volume for volumes with daughters.");
 
       RMGLog::Out(RMGLog::debug, "Physical volume '", el.physical_volume->GetName(),
           "' does not satisfy requirements for native surface sampling so resort to general "

--- a/src/RMGVertexConfinement.cc
+++ b/src/RMGVertexConfinement.cc
@@ -418,8 +418,8 @@ void RMGVertexConfinement::InitializePhysicalVolumes() {
         RMGLog::OutDev(RMGLog::debug, "Has daughters, containment check needed");
         el.native_sample = false;
         if (fOnSurface)
-          RMGLog::OutDev(RMGLog::warning,
-              "Surface sampling is on the outside of the mother volume for volumes with daughters.");
+          RMGLog::OutDev(RMGLog::warning, "Surface sampling is on the outside of the mother volume "
+                                          "for volumes with daughters.");
 
       } else {
         RMGLog::OutDev(RMGLog::debug, "Has no daughters, no containment check needed");

--- a/src/RMGVertexConfinement.cc
+++ b/src/RMGVertexConfinement.cc
@@ -418,8 +418,8 @@ void RMGVertexConfinement::InitializePhysicalVolumes() {
         RMGLog::OutDev(RMGLog::debug, "Has daughters, containment check needed");
         el.native_sample = false;
         if (fOnSurface)
-          RMGLog::OutDev(RMGLog::error,
-              "Surface sampling is not implemented for volumes with daughters");
+            RMGLog::OutDev(RMGLog::warning,
+                "Surface sampling is on the mother volume for volumes with daughters.");
 
       } else {
         RMGLog::OutDev(RMGLog::debug, "Has no daughters, no containment check needed");
@@ -431,8 +431,8 @@ void RMGVertexConfinement::InitializePhysicalVolumes() {
     else if (fOnSurface) {
 
       if (log_vol->GetNoDaughters() > 0)
-        RMGLog::OutDev(RMGLog::error,
-            "Surface sampling is not implemented for volumes with daughters");
+        RMGLog::OutDev(RMGLog::warning,
+            "Surface sampling is on the mother volume for volumes with daughters.");
 
       RMGLog::Out(RMGLog::debug, "Physical volume '", el.physical_volume->GetName(),
           "' does not satisfy requirements for native surface sampling so resort to general "

--- a/src/RMGVertexConfinement.cc
+++ b/src/RMGVertexConfinement.cc
@@ -418,8 +418,8 @@ void RMGVertexConfinement::InitializePhysicalVolumes() {
         RMGLog::OutDev(RMGLog::debug, "Has daughters, containment check needed");
         el.native_sample = false;
         if (fOnSurface)
-            RMGLog::OutDev(RMGLog::warning,
-                "Surface sampling is on the mother volume for volumes with daughters.");
+          RMGLog::OutDev(RMGLog::warning,
+              "Surface sampling is on the mother volume for volumes with daughters.");
 
       } else {
         RMGLog::OutDev(RMGLog::debug, "Has no daughters, no containment check needed");


### PR DESCRIPTION
I think this should work ... events will just be located on the mother volume.