### PR TITLE
populate numba cache at docker container build time

### DIFF
--- a/.dockerhub/Dockerfile
+++ b/.dockerhub/Dockerfile
@@ -34,7 +34,8 @@ RUN mkdir -p src build /opt/remage && \
         ctest --output-on-failure --label-exclude 'vis'; \
     fi && \
     cd .. && \
-    rm -rf build src
+    rm -rf build src && \
+    /opt/remage/bin/remage --help # populate numba cache
 
 ENV PATH="/opt/remage/bin:$PATH" \
     LD_LIBRARY_PATH="/opt/remage/lib:$LD_LIBRARY_PATH"


### PR DESCRIPTION
This should make sure that the numba cache is already populated when users run remage from the container. Otherwise the startup would be slow and I'm not even sure about what numba would do since the cache folder is not writable by the user...