### PR TITLE
update the default pars

### DIFF
--- a/docs/manual/output.md
+++ b/docs/manual/output.md
@@ -243,13 +243,15 @@ pointer to a new collection of clustered hits.
   similar function just needs to be written.
   :::
 
-Pre-clustering can be enabled with
+Pre-clustering is enabled by default for the Scintillator and Germanium
+output schemes, it can be disabled with the command
 <project:../rmg-commands.md#rmgoutputgermaniumclusterpreclusteroutputs> and
 similarly for the _Scintillator_ output scheme:
 <project:../rmg-commands.md#rmgoutputscintillatorclusterpreclusteroutputs>.
 
-We first organise the hits by track id (the index of the `G4Track` within the
-event). Some processes in Geant4 produce a large number of secondary tracks due
+This clustering works by by first organise the hits by track id
+(the index of the `G4Track` within the event).
+Some processes in Geant4 produce a large number of secondary tracks due
 to atomic de-excitation, these tracks typically have a very low energy and
 range (however they are still produced since production cuts are not applied
 for most gamma interactions). Thus they are not expected to impact observables
@@ -311,6 +313,14 @@ This will apply this threshold for any step where the distance to surface is
 less than the surface thickness. With this option a new cluster will also be
 formed if a step moves from the surface to bulk region of the germanium (or
 vice-versa).
+
+:::{note}
+By default pre-clustering is performed for both the _Germanium_ and _Scintillator_
+output schemes with 50 $\mu$m distance for Germanium. By default
+clustering is not applied to the surface for _Germanium_ (within the surface thickness
+set by default as 2 mm). For the _Scintillator_ output scheme we use 500 $\mu$ m cluster
+distance by default. For both outputs a 10$\mu$ m time threshold is used by default.
+:::
 
 These options provide a sophisticated mechanism for handling the surface of
 HPGe detectors!

--- a/include/RMGGermaniumOutputScheme.hh
+++ b/include/RMGGermaniumOutputScheme.hh
@@ -138,7 +138,7 @@ class RMGGermaniumOutputScheme : public RMGVOutputScheme {
     bool fStoreSinglePrecisionPosition = false;
 
     bool fStoreTrackID = false;
-    bool fPreClusterHits = false;
+    bool fPreClusterHits = true;
 
     /** @brief Parameters for pre-clustering. */
     RMGOutputTools::ClusterPars fPreClusterPars{};

--- a/include/RMGScintillatorOutputScheme.hh
+++ b/include/RMGScintillatorOutputScheme.hh
@@ -112,7 +112,7 @@ class RMGScintillatorOutputScheme : public RMGVOutputScheme {
     bool fStoreSinglePrecisionPosition = false;
     bool fStoreTrackID = false;
 
-    bool fPreClusterHits = false;
+    bool fPreClusterHits = True;
     bool fDiscardZeroEnergyHits = true;
 
     /** @brief Parameters for pre-clustering. */

--- a/include/RMGScintillatorOutputScheme.hh
+++ b/include/RMGScintillatorOutputScheme.hh
@@ -112,7 +112,7 @@ class RMGScintillatorOutputScheme : public RMGVOutputScheme {
     bool fStoreSinglePrecisionPosition = false;
     bool fStoreTrackID = false;
 
-    bool fPreClusterHits = True;
+    bool fPreClusterHits = true;
     bool fDiscardZeroEnergyHits = true;
 
     /** @brief Parameters for pre-clustering. */

--- a/python/remage/cli.py
+++ b/python/remage/cli.py
@@ -384,6 +384,7 @@ def remage_run_from_args(
                 stp_files=original_files,
                 glm_files=None,
                 hit_files=remage_files,
+                out_field="stp",
             )
 
         # set the merged output file for downstream consumers.

--- a/src/RMGGermaniumOutputScheme.cc
+++ b/src/RMGGermaniumOutputScheme.cc
@@ -38,12 +38,12 @@ RMGGermaniumOutputScheme::RMGGermaniumOutputScheme() {
 
   // set default clustering parameters
   fPreClusterPars.cluster_time_threshold = 10 * u::us;
-  fPreClusterPars.cluster_distance = 10 * u::um;
-  fPreClusterPars.cluster_distance_surface = 1 * u::um;
+  fPreClusterPars.cluster_distance = 50 * u::um;
+  fPreClusterPars.cluster_distance_surface = 0 * u::um;
   fPreClusterPars.surface_thickness = 2 * u::mm;
   fPreClusterPars.track_energy_threshold = 10 * u::keV;
-  fPreClusterPars.combine_low_energy_tracks = false;
-  fPreClusterPars.reassign_gamma_energy = false;
+  fPreClusterPars.combine_low_energy_tracks = true;
+  fPreClusterPars.reassign_gamma_energy = true;
 
   this->DefineCommands();
 }

--- a/src/RMGScintillatorOutputScheme.cc
+++ b/src/RMGScintillatorOutputScheme.cc
@@ -37,10 +37,10 @@ RMGScintillatorOutputScheme::RMGScintillatorOutputScheme() {
 
   // set default clustering parameters
   fPreClusterPars.cluster_time_threshold = 10 * u::us;
-  fPreClusterPars.cluster_distance = 100 * u::um;
+  fPreClusterPars.cluster_distance = 500 * u::um;
   fPreClusterPars.track_energy_threshold = 10 * u::keV;
-  fPreClusterPars.combine_low_energy_tracks = false;
-  fPreClusterPars.reassign_gamma_energy = false;
+  fPreClusterPars.combine_low_energy_tracks = true;
+  fPreClusterPars.reassign_gamma_energy = true;
 
   this->DefineCommands();
 }


### PR DESCRIPTION
Justifications [[here]](https://docs.google.com/presentation/d/1FgzLuQQN1ej4WSvdsH1eEcNkhRBq3BEnGdfQCcV2w4s/edit?slide=id.g355a9320ae0_0_176#slide=id.g355a9320ae0_0_176)

* Turn on pre-cluster by default
* Use 50 um for Germanium and 500 um for Scintillator
* Combined low energy e- tracks and redistribute gamma energy
* Keep production cuts at their current default
* Update the docs
* Change the lh5 table to be `stp` also in reshaped files