### PR TITLE
Update reboost version to have correct units

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "legend-pydataobj >=1.11.12,<1.12",
   "colorlog",
   "tol_colors",
-  "reboost ==0.2.5",
+  "reboost >=0.2.7, <0.3",
 ]
 
 [project.optional-dependencies]

--- a/tests/output/macros/ntuple-per-det-jag.hdf5ls-lh5
+++ b/tests/output/macros/ntuple-per-det-jag.hdf5ls-lh5
@@ -1,98 +1,98 @@
-stp : {'datatype': 'struct{det001,det002,det011,det012,vertices}'}
+stp : {'datatype': 'struct{det001,det002,det011,det012}'}
 stp/det001 : {'datatype': 'table{edep,evtid,particle,time,xloc,yloc,zloc}'}
-stp/det001/edep : {'datatype': 'array<1>{array<1>{real}}', 'units': 'keV'}
+stp/det001/edep : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det001/edep/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det001/edep/flattened_data : {'datatype': 'array<1>{real}'}
+stp/det001/edep/flattened_data : {'datatype': 'array<1>{real}', 'units': 'keV'}
 stp/det001/evtid : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det001/evtid/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/det001/evtid/flattened_data : {'datatype': 'array<1>{real}'}
 stp/det001/particle : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det001/particle/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/det001/particle/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det001/time : {'datatype': 'array<1>{array<1>{real}}', 'units': 'ns'}
+stp/det001/time : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det001/time/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det001/time/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det001/xloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det001/time/flattened_data : {'datatype': 'array<1>{real}', 'units': 'ns'}
+stp/det001/xloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det001/xloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det001/xloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det001/yloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det001/xloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/det001/yloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det001/yloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det001/yloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det001/zloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det001/yloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/det001/zloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det001/zloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det001/zloc/flattened_data : {'datatype': 'array<1>{real}'}
+stp/det001/zloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
 stp/det002 : {'datatype': 'table{edep,evtid,particle,time,xloc,yloc,zloc}'}
-stp/det002/edep : {'datatype': 'array<1>{array<1>{real}}', 'units': 'keV'}
+stp/det002/edep : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det002/edep/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det002/edep/flattened_data : {'datatype': 'array<1>{real}'}
+stp/det002/edep/flattened_data : {'datatype': 'array<1>{real}', 'units': 'keV'}
 stp/det002/evtid : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det002/evtid/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/det002/evtid/flattened_data : {'datatype': 'array<1>{real}'}
 stp/det002/particle : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det002/particle/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/det002/particle/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det002/time : {'datatype': 'array<1>{array<1>{real}}', 'units': 'ns'}
+stp/det002/time : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det002/time/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det002/time/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det002/xloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det002/time/flattened_data : {'datatype': 'array<1>{real}', 'units': 'ns'}
+stp/det002/xloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det002/xloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det002/xloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det002/yloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det002/xloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/det002/yloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det002/yloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det002/yloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det002/zloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det002/yloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/det002/zloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det002/zloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det002/zloc/flattened_data : {'datatype': 'array<1>{real}'}
+stp/det002/zloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
 stp/det011 : {'datatype': 'table{dist_to_surf,edep,evtid,particle,time,xloc,yloc,zloc}'}
-stp/det011/dist_to_surf : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det011/dist_to_surf : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det011/dist_to_surf/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det011/dist_to_surf/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det011/edep : {'datatype': 'array<1>{array<1>{real}}', 'units': 'keV'}
+stp/det011/dist_to_surf/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/det011/edep : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det011/edep/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det011/edep/flattened_data : {'datatype': 'array<1>{real}'}
+stp/det011/edep/flattened_data : {'datatype': 'array<1>{real}', 'units': 'keV'}
 stp/det011/evtid : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det011/evtid/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/det011/evtid/flattened_data : {'datatype': 'array<1>{real}'}
 stp/det011/particle : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det011/particle/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/det011/particle/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det011/time : {'datatype': 'array<1>{array<1>{real}}', 'units': 'ns'}
+stp/det011/time : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det011/time/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det011/time/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det011/xloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det011/time/flattened_data : {'datatype': 'array<1>{real}', 'units': 'ns'}
+stp/det011/xloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det011/xloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det011/xloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det011/yloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det011/xloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/det011/yloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det011/yloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det011/yloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det011/zloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det011/yloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/det011/zloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det011/zloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det011/zloc/flattened_data : {'datatype': 'array<1>{real}'}
+stp/det011/zloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
 stp/det012 : {'datatype': 'table{dist_to_surf,edep,evtid,particle,time,xloc,yloc,zloc}'}
-stp/det012/dist_to_surf : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det012/dist_to_surf : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det012/dist_to_surf/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det012/dist_to_surf/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det012/edep : {'datatype': 'array<1>{array<1>{real}}', 'units': 'keV'}
+stp/det012/dist_to_surf/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/det012/edep : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det012/edep/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det012/edep/flattened_data : {'datatype': 'array<1>{real}'}
+stp/det012/edep/flattened_data : {'datatype': 'array<1>{real}', 'units': 'keV'}
 stp/det012/evtid : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det012/evtid/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/det012/evtid/flattened_data : {'datatype': 'array<1>{real}'}
 stp/det012/particle : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det012/particle/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/det012/particle/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det012/time : {'datatype': 'array<1>{array<1>{real}}', 'units': 'ns'}
+stp/det012/time : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det012/time/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det012/time/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det012/xloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det012/time/flattened_data : {'datatype': 'array<1>{real}', 'units': 'ns'}
+stp/det012/xloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det012/xloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det012/xloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det012/yloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det012/xloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/det012/yloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det012/yloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det012/yloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det012/zloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det012/yloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/det012/zloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det012/zloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det012/zloc/flattened_data : {'datatype': 'array<1>{real}'}
+stp/det012/zloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
 stp/vertices : {'datatype': 'table{evtid,n_part,time,xloc,yloc,zloc}'}
 stp/vertices/evtid : {'datatype': 'array<1>{real}'}
 stp/vertices/n_part : {'datatype': 'array<1>{real}'}

--- a/tests/output/macros/ntuple-per-det-vol-jag.hdf5ls-lh5
+++ b/tests/output/macros/ntuple-per-det-vol-jag.hdf5ls-lh5
@@ -1,98 +1,98 @@
-stp : {'datatype': 'struct{det1,det2,scint1,scint2,vertices}'}
+stp : {'datatype': 'struct{det1,det2,scint1,scint2}'}
 stp/det1 : {'datatype': 'table{dist_to_surf,edep,evtid,particle,time,xloc,yloc,zloc}'}
-stp/det1/dist_to_surf : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det1/dist_to_surf : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det1/dist_to_surf/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det1/dist_to_surf/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det1/edep : {'datatype': 'array<1>{array<1>{real}}', 'units': 'keV'}
+stp/det1/dist_to_surf/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/det1/edep : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det1/edep/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det1/edep/flattened_data : {'datatype': 'array<1>{real}'}
+stp/det1/edep/flattened_data : {'datatype': 'array<1>{real}', 'units': 'keV'}
 stp/det1/evtid : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det1/evtid/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/det1/evtid/flattened_data : {'datatype': 'array<1>{real}'}
 stp/det1/particle : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det1/particle/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/det1/particle/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det1/time : {'datatype': 'array<1>{array<1>{real}}', 'units': 'ns'}
+stp/det1/time : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det1/time/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det1/time/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det1/xloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det1/time/flattened_data : {'datatype': 'array<1>{real}', 'units': 'ns'}
+stp/det1/xloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det1/xloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det1/xloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det1/yloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det1/xloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/det1/yloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det1/yloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det1/yloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det1/zloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det1/yloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/det1/zloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det1/zloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det1/zloc/flattened_data : {'datatype': 'array<1>{real}'}
+stp/det1/zloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
 stp/det2 : {'datatype': 'table{dist_to_surf,edep,evtid,particle,time,xloc,yloc,zloc}'}
-stp/det2/dist_to_surf : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det2/dist_to_surf : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det2/dist_to_surf/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det2/dist_to_surf/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det2/edep : {'datatype': 'array<1>{array<1>{real}}', 'units': 'keV'}
+stp/det2/dist_to_surf/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/det2/edep : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det2/edep/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det2/edep/flattened_data : {'datatype': 'array<1>{real}'}
+stp/det2/edep/flattened_data : {'datatype': 'array<1>{real}', 'units': 'keV'}
 stp/det2/evtid : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det2/evtid/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/det2/evtid/flattened_data : {'datatype': 'array<1>{real}'}
 stp/det2/particle : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det2/particle/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/det2/particle/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det2/time : {'datatype': 'array<1>{array<1>{real}}', 'units': 'ns'}
+stp/det2/time : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det2/time/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det2/time/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det2/xloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det2/time/flattened_data : {'datatype': 'array<1>{real}', 'units': 'ns'}
+stp/det2/xloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det2/xloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det2/xloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det2/yloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det2/xloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/det2/yloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det2/yloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det2/yloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/det2/zloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/det2/yloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/det2/zloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/det2/zloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/det2/zloc/flattened_data : {'datatype': 'array<1>{real}'}
+stp/det2/zloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
 stp/scint1 : {'datatype': 'table{edep,evtid,particle,time,xloc,yloc,zloc}'}
-stp/scint1/edep : {'datatype': 'array<1>{array<1>{real}}', 'units': 'keV'}
+stp/scint1/edep : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scint1/edep/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scint1/edep/flattened_data : {'datatype': 'array<1>{real}'}
+stp/scint1/edep/flattened_data : {'datatype': 'array<1>{real}', 'units': 'keV'}
 stp/scint1/evtid : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scint1/evtid/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/scint1/evtid/flattened_data : {'datatype': 'array<1>{real}'}
 stp/scint1/particle : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scint1/particle/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/scint1/particle/flattened_data : {'datatype': 'array<1>{real}'}
-stp/scint1/time : {'datatype': 'array<1>{array<1>{real}}', 'units': 'ns'}
+stp/scint1/time : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scint1/time/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scint1/time/flattened_data : {'datatype': 'array<1>{real}'}
-stp/scint1/xloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/scint1/time/flattened_data : {'datatype': 'array<1>{real}', 'units': 'ns'}
+stp/scint1/xloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scint1/xloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scint1/xloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/scint1/yloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/scint1/xloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/scint1/yloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scint1/yloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scint1/yloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/scint1/zloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/scint1/yloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/scint1/zloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scint1/zloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scint1/zloc/flattened_data : {'datatype': 'array<1>{real}'}
+stp/scint1/zloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
 stp/scint2 : {'datatype': 'table{edep,evtid,particle,time,xloc,yloc,zloc}'}
-stp/scint2/edep : {'datatype': 'array<1>{array<1>{real}}', 'units': 'keV'}
+stp/scint2/edep : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scint2/edep/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scint2/edep/flattened_data : {'datatype': 'array<1>{real}'}
+stp/scint2/edep/flattened_data : {'datatype': 'array<1>{real}', 'units': 'keV'}
 stp/scint2/evtid : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scint2/evtid/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/scint2/evtid/flattened_data : {'datatype': 'array<1>{real}'}
 stp/scint2/particle : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scint2/particle/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/scint2/particle/flattened_data : {'datatype': 'array<1>{real}'}
-stp/scint2/time : {'datatype': 'array<1>{array<1>{real}}', 'units': 'ns'}
+stp/scint2/time : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scint2/time/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scint2/time/flattened_data : {'datatype': 'array<1>{real}'}
-stp/scint2/xloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/scint2/time/flattened_data : {'datatype': 'array<1>{real}', 'units': 'ns'}
+stp/scint2/xloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scint2/xloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scint2/xloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/scint2/yloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/scint2/xloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/scint2/yloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scint2/yloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scint2/yloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/scint2/zloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/scint2/yloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/scint2/zloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scint2/zloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scint2/zloc/flattened_data : {'datatype': 'array<1>{real}'}
+stp/scint2/zloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
 stp/vertices : {'datatype': 'table{evtid,n_part,time,xloc,yloc,zloc}'}
 stp/vertices/evtid : {'datatype': 'array<1>{real}'}
 stp/vertices/n_part : {'datatype': 'array<1>{real}'}

--- a/tests/output/macros/ntuple-single-table-jag.hdf5ls-lh5
+++ b/tests/output/macros/ntuple-single-table-jag.hdf5ls-lh5
@@ -1,57 +1,57 @@
-stp : {'datatype': 'struct{germanium,scintillator,vertices}'}
+stp : {'datatype': 'struct{germanium,scintillator}'}
 stp/germanium : {'datatype': 'table{det_uid,dist_to_surf,edep,evtid,particle,time,xloc,yloc,zloc}'}
 stp/germanium/det_uid : {'datatype': 'array<1>{array<1>{real}}'}
 stp/germanium/det_uid/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/germanium/det_uid/flattened_data : {'datatype': 'array<1>{real}'}
-stp/germanium/dist_to_surf : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/germanium/dist_to_surf : {'datatype': 'array<1>{array<1>{real}}'}
 stp/germanium/dist_to_surf/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/germanium/dist_to_surf/flattened_data : {'datatype': 'array<1>{real}'}
-stp/germanium/edep : {'datatype': 'array<1>{array<1>{real}}', 'units': 'keV'}
+stp/germanium/dist_to_surf/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/germanium/edep : {'datatype': 'array<1>{array<1>{real}}'}
 stp/germanium/edep/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/germanium/edep/flattened_data : {'datatype': 'array<1>{real}'}
+stp/germanium/edep/flattened_data : {'datatype': 'array<1>{real}', 'units': 'keV'}
 stp/germanium/evtid : {'datatype': 'array<1>{array<1>{real}}'}
 stp/germanium/evtid/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/germanium/evtid/flattened_data : {'datatype': 'array<1>{real}'}
 stp/germanium/particle : {'datatype': 'array<1>{array<1>{real}}'}
 stp/germanium/particle/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/germanium/particle/flattened_data : {'datatype': 'array<1>{real}'}
-stp/germanium/time : {'datatype': 'array<1>{array<1>{real}}', 'units': 'ns'}
+stp/germanium/time : {'datatype': 'array<1>{array<1>{real}}'}
 stp/germanium/time/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/germanium/time/flattened_data : {'datatype': 'array<1>{real}'}
-stp/germanium/xloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/germanium/time/flattened_data : {'datatype': 'array<1>{real}', 'units': 'ns'}
+stp/germanium/xloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/germanium/xloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/germanium/xloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/germanium/yloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/germanium/xloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/germanium/yloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/germanium/yloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/germanium/yloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/germanium/zloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/germanium/yloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/germanium/zloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/germanium/zloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/germanium/zloc/flattened_data : {'datatype': 'array<1>{real}'}
+stp/germanium/zloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
 stp/scintillator : {'datatype': 'table{det_uid,edep,evtid,particle,time,xloc,yloc,zloc}'}
 stp/scintillator/det_uid : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scintillator/det_uid/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/scintillator/det_uid/flattened_data : {'datatype': 'array<1>{real}'}
-stp/scintillator/edep : {'datatype': 'array<1>{array<1>{real}}', 'units': 'keV'}
+stp/scintillator/edep : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scintillator/edep/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scintillator/edep/flattened_data : {'datatype': 'array<1>{real}'}
+stp/scintillator/edep/flattened_data : {'datatype': 'array<1>{real}', 'units': 'keV'}
 stp/scintillator/evtid : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scintillator/evtid/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/scintillator/evtid/flattened_data : {'datatype': 'array<1>{real}'}
 stp/scintillator/particle : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scintillator/particle/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/scintillator/particle/flattened_data : {'datatype': 'array<1>{real}'}
-stp/scintillator/time : {'datatype': 'array<1>{array<1>{real}}', 'units': 'ns'}
+stp/scintillator/time : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scintillator/time/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scintillator/time/flattened_data : {'datatype': 'array<1>{real}'}
-stp/scintillator/xloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/scintillator/time/flattened_data : {'datatype': 'array<1>{real}', 'units': 'ns'}
+stp/scintillator/xloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scintillator/xloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scintillator/xloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/scintillator/yloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/scintillator/xloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/scintillator/yloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scintillator/yloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scintillator/yloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/scintillator/zloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/scintillator/yloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/scintillator/zloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scintillator/zloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scintillator/zloc/flattened_data : {'datatype': 'array<1>{real}'}
+stp/scintillator/zloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
 stp/vertices : {'datatype': 'table{evtid,n_part,time,xloc,yloc,zloc}'}
 stp/vertices/evtid : {'datatype': 'array<1>{real}'}
 stp/vertices/n_part : {'datatype': 'array<1>{real}'}

--- a/tests/output/macros/ntuple-single-table-with-tracks-jag.hdf5ls-lh5
+++ b/tests/output/macros/ntuple-single-table-with-tracks-jag.hdf5ls-lh5
@@ -1,14 +1,14 @@
-stp : {'datatype': 'struct{germanium,scintillator,vertices}'}
+stp : {'datatype': 'struct{germanium,scintillator}'}
 stp/germanium : {'datatype': 'table{det_uid,dist_to_surf,edep,evtid,parent_trackid,particle,time,trackid,xloc,yloc,zloc}'}
 stp/germanium/det_uid : {'datatype': 'array<1>{array<1>{real}}'}
 stp/germanium/det_uid/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/germanium/det_uid/flattened_data : {'datatype': 'array<1>{real}'}
-stp/germanium/dist_to_surf : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/germanium/dist_to_surf : {'datatype': 'array<1>{array<1>{real}}'}
 stp/germanium/dist_to_surf/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/germanium/dist_to_surf/flattened_data : {'datatype': 'array<1>{real}'}
-stp/germanium/edep : {'datatype': 'array<1>{array<1>{real}}', 'units': 'keV'}
+stp/germanium/dist_to_surf/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/germanium/edep : {'datatype': 'array<1>{array<1>{real}}'}
 stp/germanium/edep/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/germanium/edep/flattened_data : {'datatype': 'array<1>{real}'}
+stp/germanium/edep/flattened_data : {'datatype': 'array<1>{real}', 'units': 'keV'}
 stp/germanium/evtid : {'datatype': 'array<1>{array<1>{real}}'}
 stp/germanium/evtid/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/germanium/evtid/flattened_data : {'datatype': 'array<1>{real}'}
@@ -18,46 +18,46 @@ stp/germanium/parent_trackid/flattened_data : {'datatype': 'array<1>{real}'}
 stp/germanium/particle : {'datatype': 'array<1>{array<1>{real}}'}
 stp/germanium/particle/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/germanium/particle/flattened_data : {'datatype': 'array<1>{real}'}
-stp/germanium/time : {'datatype': 'array<1>{array<1>{real}}', 'units': 'ns'}
+stp/germanium/time : {'datatype': 'array<1>{array<1>{real}}'}
 stp/germanium/time/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/germanium/time/flattened_data : {'datatype': 'array<1>{real}'}
+stp/germanium/time/flattened_data : {'datatype': 'array<1>{real}', 'units': 'ns'}
 stp/germanium/trackid : {'datatype': 'array<1>{array<1>{real}}'}
 stp/germanium/trackid/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/germanium/trackid/flattened_data : {'datatype': 'array<1>{real}'}
-stp/germanium/xloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/germanium/xloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/germanium/xloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/germanium/xloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/germanium/yloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/germanium/xloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/germanium/yloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/germanium/yloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/germanium/yloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/germanium/zloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/germanium/yloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/germanium/zloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/germanium/zloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/germanium/zloc/flattened_data : {'datatype': 'array<1>{real}'}
+stp/germanium/zloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
 stp/scintillator : {'datatype': 'table{det_uid,edep,evtid,particle,time,xloc,yloc,zloc}'}
 stp/scintillator/det_uid : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scintillator/det_uid/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/scintillator/det_uid/flattened_data : {'datatype': 'array<1>{real}'}
-stp/scintillator/edep : {'datatype': 'array<1>{array<1>{real}}', 'units': 'keV'}
+stp/scintillator/edep : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scintillator/edep/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scintillator/edep/flattened_data : {'datatype': 'array<1>{real}'}
+stp/scintillator/edep/flattened_data : {'datatype': 'array<1>{real}', 'units': 'keV'}
 stp/scintillator/evtid : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scintillator/evtid/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/scintillator/evtid/flattened_data : {'datatype': 'array<1>{real}'}
 stp/scintillator/particle : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scintillator/particle/cumulative_length : {'datatype': 'array<1>{real}'}
 stp/scintillator/particle/flattened_data : {'datatype': 'array<1>{real}'}
-stp/scintillator/time : {'datatype': 'array<1>{array<1>{real}}', 'units': 'ns'}
+stp/scintillator/time : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scintillator/time/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scintillator/time/flattened_data : {'datatype': 'array<1>{real}'}
-stp/scintillator/xloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/scintillator/time/flattened_data : {'datatype': 'array<1>{real}', 'units': 'ns'}
+stp/scintillator/xloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scintillator/xloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scintillator/xloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/scintillator/yloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/scintillator/xloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/scintillator/yloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scintillator/yloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scintillator/yloc/flattened_data : {'datatype': 'array<1>{real}'}
-stp/scintillator/zloc : {'datatype': 'array<1>{array<1>{real}}', 'units': 'm'}
+stp/scintillator/yloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
+stp/scintillator/zloc : {'datatype': 'array<1>{array<1>{real}}'}
 stp/scintillator/zloc/cumulative_length : {'datatype': 'array<1>{real}'}
-stp/scintillator/zloc/flattened_data : {'datatype': 'array<1>{real}'}
+stp/scintillator/zloc/flattened_data : {'datatype': 'array<1>{real}', 'units': 'm'}
 stp/vertices : {'datatype': 'table{evtid,n_part,time,xloc,yloc,zloc}'}
 stp/vertices/evtid : {'datatype': 'array<1>{real}'}
 stp/vertices/n_part : {'datatype': 'array<1>{real}'}

--- a/tests/output/run-test-hdf5.sh
+++ b/tests/output/run-test-hdf5.sh
@@ -17,6 +17,7 @@ output_exp="macros/${4/.mac/.hdf5ls}"
 output_exp_lh5="macros/${4/.mac/.hdf5ls-lh5}"
 output_exp_lh5_jag="macros/${4/.mac/-jag.hdf5ls-lh5}"
 
+set -vx
 
 # -----------------------
 # TEST remage HDF5 output
@@ -58,9 +59,11 @@ diff "$output_dump_lh5" "$output_exp_lh5"
 "$python_path" ./visit-hdf5.py "$output_lh5" --dump-attrs > "$output_dump_lh5"
 diff "$output_dump_lh5" "$output_exp_lh5"
 
-# run remage, produce *jagaped* lh5 output.
+# run remage, produce *jagged* lh5 output.
 "$rmg" -g gdml/geometry.gdml -o "$output_lh5_jag" -w -- "$macro"
 
 # extract written lh5 structure & compare with expectation.
 "$python_path" ./visit-hdf5.py "$output_lh5_jag" --dump-attrs > "$output_dump_lh5_jag"
 diff "$output_dump_lh5_jag" "$output_exp_lh5_jag"
+
+set +vx


### PR DESCRIPTION
Now physical units are attached to `VectorOfVectors`' `flattened_data`.