### PR TITLE
Wrap 2vbb and 0vbb in remage

### DIFF
--- a/docs/rmg-commands.md
+++ b/docs/rmg-commands.md
@@ -1141,10 +1141,11 @@ Commands for controlling generators
 
 **Sub-directories:**
 
+* `/RMG/Generator/Confinement/` – Commands for controlling primary confinement
 * `/RMG/Generator/MUSUNCosmicMuons/` – Commands for controlling the MUSUN µ generator
 * `/RMG/Generator/CosmicMuons/` – Commands for controlling the µ generator
+* `/RMG/Generator/BxDecay0/` – Commands for controlling the BxDecay0 generator
 * `/RMG/Generator/FromFile/` – Commands for controlling reading event data from file
-* `/RMG/Generator/Confinement/` – Commands for controlling primary confinement
 
 **Commands:**
 
@@ -1169,268 +1170,6 @@ Select event generator
   * **Parameter type** – `s`
   * **Omittable** – `False`
   * **Candidates** – `G4gun GPS BxDecay0 FromFile CosmicMuons MUSUNCosmicMuons UserDefined Undefined`
-* **Allowed states** – `PreInit Idle`
-
-## `/RMG/Generator/MUSUNCosmicMuons/`
-
-Commands for controlling the MUSUN µ generator
-
-
-**Commands:**
-
-* `MUSUNFile` – Set the MUSUN input file
-
-### `/RMG/Generator/MUSUNCosmicMuons/MUSUNFile`
-
-Set the MUSUN input file
-
-* **Parameter** – `MUSUNFileName`
-  * **Parameter type** – `s`
-  * **Omittable** – `False`
-* **Allowed states** – `PreInit Idle`
-
-## `/RMG/Generator/CosmicMuons/`
-
-Commands for controlling the µ generator
-
-
-**Commands:**
-
-* `SkyShape` – Geometrical shape of the µ generation surface
-* `SkyPlaneSize` – Length of the side of the sky, if it has a planar shape
-* `SkyPlaneHeight` – Height of the sky, if it has a planar shape
-* `MomentumMin` – Minimum momentum of the generated muon
-* `MomentumMax` – Maximum momentum of the generated muon
-* `ThetaMin` – Minimum azimutal angle of the generated muon momentum
-* `ThetaMax` – Maximum azimutal angle of the generated muon momentum
-* `PhiMin` – Minimum zenith angle of the generated muon momentum
-* `PhiMax` – Maximum zenith angle of the generated muon momentum
-* `SpherePositionThetaMin` – Minimum azimutal angle of the generated muon position on the sphere
-* `SpherePositionThetaMax` – Maximum azimutal angle of the generated muon position on the sphere
-* `SpherePositionPhiMin` – Minimum zenith angle of the generated muon position on the sphere
-* `SpherePositionPhiMax` – Maximum zenith angle of the generated muon position on the sphere
-
-### `/RMG/Generator/CosmicMuons/SkyShape`
-
-Geometrical shape of the µ generation surface
-
-* **Parameter** – `shape`
-  * **Parameter type** – `s`
-  * **Omittable** – `False`
-  * **Candidates** – `Plane Sphere`
-* **Allowed states** – `PreInit Idle`
-
-### `/RMG/Generator/CosmicMuons/SkyPlaneSize`
-
-Length of the side of the sky, if it has a planar shape
-
-* **Range of parameters** – `l > 0`
-* **Parameter** – `l`
-  * **Parameter type** – `d`
-  * **Omittable** – `False`
-* **Parameter** – `Unit`
-  * **Parameter type** – `s`
-  * **Omittable** – `True`
-  * **Default value** – `m`
-  * **Candidates** – `pc km m cm mm um nm Ang fm parsec kilometer meter centimeter millimeter micrometer nanometer angstrom fermi`
-* **Allowed states** – `PreInit Idle`
-
-### `/RMG/Generator/CosmicMuons/SkyPlaneHeight`
-
-Height of the sky, if it has a planar shape
-
-* **Range of parameters** – `l > 0`
-* **Parameter** – `l`
-  * **Parameter type** – `d`
-  * **Omittable** – `False`
-* **Parameter** – `Unit`
-  * **Parameter type** – `s`
-  * **Omittable** – `True`
-  * **Default value** – `m`
-  * **Candidates** – `pc km m cm mm um nm Ang fm parsec kilometer meter centimeter millimeter micrometer nanometer angstrom fermi`
-* **Allowed states** – `PreInit Idle`
-
-### `/RMG/Generator/CosmicMuons/MomentumMin`
-
-Minimum momentum of the generated muon
-
-* **Range of parameters** – `p >= 0 && p < 1000`
-* **Parameter** – `p`
-  * **Parameter type** – `d`
-  * **Omittable** – `False`
-* **Parameter** – `Unit`
-  * **Parameter type** – `s`
-  * **Omittable** – `True`
-  * **Default value** – `GeV/c`
-  * **Candidates** – `eV/c keV/c MeV/c GeV/c TeV/c eV/c keV/c MeV/c GeV/c TeV/c`
-* **Allowed states** – `PreInit Idle`
-
-### `/RMG/Generator/CosmicMuons/MomentumMax`
-
-Maximum momentum of the generated muon
-
-* **Range of parameters** – `p > 0 && p <= 1000`
-* **Parameter** – `p`
-  * **Parameter type** – `d`
-  * **Omittable** – `False`
-* **Parameter** – `Unit`
-  * **Parameter type** – `s`
-  * **Omittable** – `True`
-  * **Default value** – `GeV/c`
-  * **Candidates** – `eV/c keV/c MeV/c GeV/c TeV/c eV/c keV/c MeV/c GeV/c TeV/c`
-* **Allowed states** – `PreInit Idle`
-
-### `/RMG/Generator/CosmicMuons/ThetaMin`
-
-Minimum azimutal angle of the generated muon momentum
-
-* **Range of parameters** – `a >= 0 && a < 90`
-* **Parameter** – `a`
-  * **Parameter type** – `d`
-  * **Omittable** – `False`
-* **Parameter** – `Unit`
-  * **Parameter type** – `s`
-  * **Omittable** – `True`
-  * **Default value** – `deg`
-  * **Candidates** – `rad mrad deg radian milliradian degree`
-* **Allowed states** – `PreInit Idle`
-
-### `/RMG/Generator/CosmicMuons/ThetaMax`
-
-Maximum azimutal angle of the generated muon momentum
-
-* **Range of parameters** – `a > 0 && a <= 90`
-* **Parameter** – `a`
-  * **Parameter type** – `d`
-  * **Omittable** – `False`
-* **Parameter** – `Unit`
-  * **Parameter type** – `s`
-  * **Omittable** – `True`
-  * **Default value** – `deg`
-  * **Candidates** – `rad mrad deg radian milliradian degree`
-* **Allowed states** – `PreInit Idle`
-
-### `/RMG/Generator/CosmicMuons/PhiMin`
-
-Minimum zenith angle of the generated muon momentum
-
-* **Range of parameters** – `a >= 0 && a < 360`
-* **Parameter** – `a`
-  * **Parameter type** – `d`
-  * **Omittable** – `False`
-* **Parameter** – `Unit`
-  * **Parameter type** – `s`
-  * **Omittable** – `True`
-  * **Default value** – `deg`
-  * **Candidates** – `rad mrad deg radian milliradian degree`
-* **Allowed states** – `PreInit Idle`
-
-### `/RMG/Generator/CosmicMuons/PhiMax`
-
-Maximum zenith angle of the generated muon momentum
-
-* **Range of parameters** – `a > 0 && a <= 360`
-* **Parameter** – `a`
-  * **Parameter type** – `d`
-  * **Omittable** – `False`
-* **Parameter** – `Unit`
-  * **Parameter type** – `s`
-  * **Omittable** – `True`
-  * **Default value** – `deg`
-  * **Candidates** – `rad mrad deg radian milliradian degree`
-* **Allowed states** – `PreInit Idle`
-
-### `/RMG/Generator/CosmicMuons/SpherePositionThetaMin`
-
-Minimum azimutal angle of the generated muon position on the sphere
-
-* **Range of parameters** – `a >= 0 && a < 90`
-* **Parameter** – `a`
-  * **Parameter type** – `d`
-  * **Omittable** – `False`
-* **Parameter** – `Unit`
-  * **Parameter type** – `s`
-  * **Omittable** – `True`
-  * **Default value** – `deg`
-  * **Candidates** – `rad mrad deg radian milliradian degree`
-* **Allowed states** – `PreInit Idle`
-
-### `/RMG/Generator/CosmicMuons/SpherePositionThetaMax`
-
-Maximum azimutal angle of the generated muon position on the sphere
-
-* **Range of parameters** – `a > 0 && a <= 90`
-* **Parameter** – `a`
-  * **Parameter type** – `d`
-  * **Omittable** – `False`
-* **Parameter** – `Unit`
-  * **Parameter type** – `s`
-  * **Omittable** – `True`
-  * **Default value** – `deg`
-  * **Candidates** – `rad mrad deg radian milliradian degree`
-* **Allowed states** – `PreInit Idle`
-
-### `/RMG/Generator/CosmicMuons/SpherePositionPhiMin`
-
-Minimum zenith angle of the generated muon position on the sphere
-
-* **Range of parameters** – `a >= 0 && a < 360`
-* **Parameter** – `a`
-  * **Parameter type** – `d`
-  * **Omittable** – `False`
-* **Parameter** – `Unit`
-  * **Parameter type** – `s`
-  * **Omittable** – `True`
-  * **Default value** – `deg`
-  * **Candidates** – `rad mrad deg radian milliradian degree`
-* **Allowed states** – `PreInit Idle`
-
-### `/RMG/Generator/CosmicMuons/SpherePositionPhiMax`
-
-Maximum zenith angle of the generated muon position on the sphere
-
-* **Range of parameters** – `a > 0 && a <= 360`
-* **Parameter** – `a`
-  * **Parameter type** – `d`
-  * **Omittable** – `False`
-* **Parameter** – `Unit`
-  * **Parameter type** – `s`
-  * **Omittable** – `True`
-  * **Default value** – `deg`
-  * **Candidates** – `rad mrad deg radian milliradian degree`
-* **Allowed states** – `PreInit Idle`
-
-## `/RMG/Generator/FromFile/`
-
-Commands for controlling reading event data from file
-
-
-**Commands:**
-
-* `FileName` – Set name of the file containing vertex kinetics for the next run. See the documentation for a specification of the format.
-* `NtupleDirectory` – Change the default input directory/group for ntuples.
-
-### `/RMG/Generator/FromFile/FileName`
-
-Set name of the file containing vertex kinetics for the next run. See the documentation for a specification of the format.
-
-* **Parameter** – `filename`
-  * **Parameter type** – `s`
-  * **Omittable** – `False`
-* **Allowed states** – `PreInit Idle`
-
-### `/RMG/Generator/FromFile/NtupleDirectory`
-
-Change the default input directory/group for ntuples.
-
-:::{note}
-this option only has an effect for LH5 or HDF5 input files.
-:::
-
-* **Parameter** – `nt_directory`
-  * **Parameter type** – `s`
-  * **Omittable** – `False`
-  * **Default value** – `vtx`
 * **Allowed states** – `PreInit Idle`
 
 ## `/RMG/Generator/Confinement/`
@@ -1824,6 +1563,309 @@ Set name of the file containing vertex positions for the next run. See the docum
 * **Allowed states** – `PreInit Idle`
 
 ### `/RMG/Generator/Confinement/FromFile/NtupleDirectory`
+
+Change the default input directory/group for ntuples.
+
+:::{note}
+this option only has an effect for LH5 or HDF5 input files.
+:::
+
+* **Parameter** – `nt_directory`
+  * **Parameter type** – `s`
+  * **Omittable** – `False`
+  * **Default value** – `vtx`
+* **Allowed states** – `PreInit Idle`
+
+## `/RMG/Generator/MUSUNCosmicMuons/`
+
+Commands for controlling the MUSUN µ generator
+
+
+**Commands:**
+
+* `MUSUNFile` – Set the MUSUN input file
+
+### `/RMG/Generator/MUSUNCosmicMuons/MUSUNFile`
+
+Set the MUSUN input file
+
+* **Parameter** – `MUSUNFileName`
+  * **Parameter type** – `s`
+  * **Omittable** – `False`
+* **Allowed states** – `PreInit Idle`
+
+## `/RMG/Generator/CosmicMuons/`
+
+Commands for controlling the µ generator
+
+
+**Commands:**
+
+* `SkyShape` – Geometrical shape of the µ generation surface
+* `SkyPlaneSize` – Length of the side of the sky, if it has a planar shape
+* `SkyPlaneHeight` – Height of the sky, if it has a planar shape
+* `MomentumMin` – Minimum momentum of the generated muon
+* `MomentumMax` – Maximum momentum of the generated muon
+* `ThetaMin` – Minimum azimutal angle of the generated muon momentum
+* `ThetaMax` – Maximum azimutal angle of the generated muon momentum
+* `PhiMin` – Minimum zenith angle of the generated muon momentum
+* `PhiMax` – Maximum zenith angle of the generated muon momentum
+* `SpherePositionThetaMin` – Minimum azimutal angle of the generated muon position on the sphere
+* `SpherePositionThetaMax` – Maximum azimutal angle of the generated muon position on the sphere
+* `SpherePositionPhiMin` – Minimum zenith angle of the generated muon position on the sphere
+* `SpherePositionPhiMax` – Maximum zenith angle of the generated muon position on the sphere
+
+### `/RMG/Generator/CosmicMuons/SkyShape`
+
+Geometrical shape of the µ generation surface
+
+* **Parameter** – `shape`
+  * **Parameter type** – `s`
+  * **Omittable** – `False`
+  * **Candidates** – `Plane Sphere`
+* **Allowed states** – `PreInit Idle`
+
+### `/RMG/Generator/CosmicMuons/SkyPlaneSize`
+
+Length of the side of the sky, if it has a planar shape
+
+* **Range of parameters** – `l > 0`
+* **Parameter** – `l`
+  * **Parameter type** – `d`
+  * **Omittable** – `False`
+* **Parameter** – `Unit`
+  * **Parameter type** – `s`
+  * **Omittable** – `True`
+  * **Default value** – `m`
+  * **Candidates** – `pc km m cm mm um nm Ang fm parsec kilometer meter centimeter millimeter micrometer nanometer angstrom fermi`
+* **Allowed states** – `PreInit Idle`
+
+### `/RMG/Generator/CosmicMuons/SkyPlaneHeight`
+
+Height of the sky, if it has a planar shape
+
+* **Range of parameters** – `l > 0`
+* **Parameter** – `l`
+  * **Parameter type** – `d`
+  * **Omittable** – `False`
+* **Parameter** – `Unit`
+  * **Parameter type** – `s`
+  * **Omittable** – `True`
+  * **Default value** – `m`
+  * **Candidates** – `pc km m cm mm um nm Ang fm parsec kilometer meter centimeter millimeter micrometer nanometer angstrom fermi`
+* **Allowed states** – `PreInit Idle`
+
+### `/RMG/Generator/CosmicMuons/MomentumMin`
+
+Minimum momentum of the generated muon
+
+* **Range of parameters** – `p >= 0 && p < 1000`
+* **Parameter** – `p`
+  * **Parameter type** – `d`
+  * **Omittable** – `False`
+* **Parameter** – `Unit`
+  * **Parameter type** – `s`
+  * **Omittable** – `True`
+  * **Default value** – `GeV/c`
+  * **Candidates** – `eV/c keV/c MeV/c GeV/c TeV/c eV/c keV/c MeV/c GeV/c TeV/c`
+* **Allowed states** – `PreInit Idle`
+
+### `/RMG/Generator/CosmicMuons/MomentumMax`
+
+Maximum momentum of the generated muon
+
+* **Range of parameters** – `p > 0 && p <= 1000`
+* **Parameter** – `p`
+  * **Parameter type** – `d`
+  * **Omittable** – `False`
+* **Parameter** – `Unit`
+  * **Parameter type** – `s`
+  * **Omittable** – `True`
+  * **Default value** – `GeV/c`
+  * **Candidates** – `eV/c keV/c MeV/c GeV/c TeV/c eV/c keV/c MeV/c GeV/c TeV/c`
+* **Allowed states** – `PreInit Idle`
+
+### `/RMG/Generator/CosmicMuons/ThetaMin`
+
+Minimum azimutal angle of the generated muon momentum
+
+* **Range of parameters** – `a >= 0 && a < 90`
+* **Parameter** – `a`
+  * **Parameter type** – `d`
+  * **Omittable** – `False`
+* **Parameter** – `Unit`
+  * **Parameter type** – `s`
+  * **Omittable** – `True`
+  * **Default value** – `deg`
+  * **Candidates** – `rad mrad deg radian milliradian degree`
+* **Allowed states** – `PreInit Idle`
+
+### `/RMG/Generator/CosmicMuons/ThetaMax`
+
+Maximum azimutal angle of the generated muon momentum
+
+* **Range of parameters** – `a > 0 && a <= 90`
+* **Parameter** – `a`
+  * **Parameter type** – `d`
+  * **Omittable** – `False`
+* **Parameter** – `Unit`
+  * **Parameter type** – `s`
+  * **Omittable** – `True`
+  * **Default value** – `deg`
+  * **Candidates** – `rad mrad deg radian milliradian degree`
+* **Allowed states** – `PreInit Idle`
+
+### `/RMG/Generator/CosmicMuons/PhiMin`
+
+Minimum zenith angle of the generated muon momentum
+
+* **Range of parameters** – `a >= 0 && a < 360`
+* **Parameter** – `a`
+  * **Parameter type** – `d`
+  * **Omittable** – `False`
+* **Parameter** – `Unit`
+  * **Parameter type** – `s`
+  * **Omittable** – `True`
+  * **Default value** – `deg`
+  * **Candidates** – `rad mrad deg radian milliradian degree`
+* **Allowed states** – `PreInit Idle`
+
+### `/RMG/Generator/CosmicMuons/PhiMax`
+
+Maximum zenith angle of the generated muon momentum
+
+* **Range of parameters** – `a > 0 && a <= 360`
+* **Parameter** – `a`
+  * **Parameter type** – `d`
+  * **Omittable** – `False`
+* **Parameter** – `Unit`
+  * **Parameter type** – `s`
+  * **Omittable** – `True`
+  * **Default value** – `deg`
+  * **Candidates** – `rad mrad deg radian milliradian degree`
+* **Allowed states** – `PreInit Idle`
+
+### `/RMG/Generator/CosmicMuons/SpherePositionThetaMin`
+
+Minimum azimutal angle of the generated muon position on the sphere
+
+* **Range of parameters** – `a >= 0 && a < 90`
+* **Parameter** – `a`
+  * **Parameter type** – `d`
+  * **Omittable** – `False`
+* **Parameter** – `Unit`
+  * **Parameter type** – `s`
+  * **Omittable** – `True`
+  * **Default value** – `deg`
+  * **Candidates** – `rad mrad deg radian milliradian degree`
+* **Allowed states** – `PreInit Idle`
+
+### `/RMG/Generator/CosmicMuons/SpherePositionThetaMax`
+
+Maximum azimutal angle of the generated muon position on the sphere
+
+* **Range of parameters** – `a > 0 && a <= 90`
+* **Parameter** – `a`
+  * **Parameter type** – `d`
+  * **Omittable** – `False`
+* **Parameter** – `Unit`
+  * **Parameter type** – `s`
+  * **Omittable** – `True`
+  * **Default value** – `deg`
+  * **Candidates** – `rad mrad deg radian milliradian degree`
+* **Allowed states** – `PreInit Idle`
+
+### `/RMG/Generator/CosmicMuons/SpherePositionPhiMin`
+
+Minimum zenith angle of the generated muon position on the sphere
+
+* **Range of parameters** – `a >= 0 && a < 360`
+* **Parameter** – `a`
+  * **Parameter type** – `d`
+  * **Omittable** – `False`
+* **Parameter** – `Unit`
+  * **Parameter type** – `s`
+  * **Omittable** – `True`
+  * **Default value** – `deg`
+  * **Candidates** – `rad mrad deg radian milliradian degree`
+* **Allowed states** – `PreInit Idle`
+
+### `/RMG/Generator/CosmicMuons/SpherePositionPhiMax`
+
+Maximum zenith angle of the generated muon position on the sphere
+
+* **Range of parameters** – `a > 0 && a <= 360`
+* **Parameter** – `a`
+  * **Parameter type** – `d`
+  * **Omittable** – `False`
+* **Parameter** – `Unit`
+  * **Parameter type** – `s`
+  * **Omittable** – `True`
+  * **Default value** – `deg`
+  * **Candidates** – `rad mrad deg radian milliradian degree`
+* **Allowed states** – `PreInit Idle`
+
+## `/RMG/Generator/BxDecay0/`
+
+Commands for controlling the BxDecay0 generator
+
+
+**Commands:**
+
+* `background` – Set the isotope for the background mode of the BxDecay0 generator. E.g. 'Co60'
+* `dbd` – Set the isotope, process and energy level for the double beta decay mode of the BxDecay0 generator
+
+### `/RMG/Generator/BxDecay0/background`
+
+Set the isotope for the background mode of the BxDecay0 generator. E.g. 'Co60'
+
+* **Parameter** – `isotope`
+  * **Parameter type** – `s`
+  * **Omittable** – `False`
+  * **Candidates** – `Ac228 Am241 Ar39 Ar42 As79+Se79m Bi207+Pb207m Bi208 Bi210 Bi212+Po212 Bi214+Po214 C14 Ca48+Sc48 Cd113 Co60 Cs136 Cs137+Ba137m Eu147 Eu152 Eu154 Gd146 Hf182 I126 I133 I134 I135 K40 K42 Kr81 Kr85 Mn54 Na22 P32 Pa231 Pa234m Pb210 Pb211 Pb212 Pb214 Po210 Po218 Ra226 Ra228 Rb87 Rh106 Rn222 Sb125 Sb126 Sb133 Sr90 Ta180m-B- Ta180m-EC Ta182 Te133 Te133m Te134 Th230 Th234 Tl207 Tl208 U234 U238 Xe129m Xe131m Xe133 Xe135 Y88 Y90 Zn65 Zr96+Nb96`
+* **Allowed states** – `PreInit Idle`
+
+### `/RMG/Generator/BxDecay0/dbd`
+
+Set the isotope, process and energy level for the double beta decay mode of the BxDecay0 generator
+
+* **Parameter** – `isotope`
+    – Set the isotope for the double beta decay
+  * **Parameter type** – `s`
+  * **Omittable** – `False`
+  * **Candidates** – `Bi214 Ca40 Ca46 Ca48 Cd106 Cd108 Cd114 Cd116 Ce136 Ce138 Ce142 Dy156 Dy158 Er162 Er164 Er170 Ge76 Mo100 Mo92 Nd148 Nd150 Ni58 Os184 Os192 Pb214 Po218 Pt190 Pt198 Rn222 Ru104 Ru96 Se74 Se82 Sm144 Sm154 Sn112 Sn122 Sn124 Sr84 Te120 Te128 Te130 W180 W186 Xe136 Yb168 Yb176 Zn64 Zn70 Zr94 Zr96`
+* **Parameter** – `process`
+    – Name the decay process you want to simulate
+  * **Parameter type** – `s`
+  * **Omittable** – `False`
+  * **Candidates** – `0vbb 0vbb_lambda_0 0vbb_lambda_02 2vbb 0vbb_M1 0vbb_M2 0vbb_M3 0vbb_M7 0vbb_lambda_2 2vbb_2 0vkb 2vkb 0v2k 2v2k 2vbb_bos0 2vbb_bos2 0vbb_eta_s 0vbb_eta_nmes 2vbb_lv 0v4b`
+* **Parameter** – `level`
+    – Energy level of the daughter nucleus
+  * **Parameter type** – `i`
+  * **Omittable** – `True`
+  * **Default value** – `0`
+* **Allowed states** – `PreInit Idle`
+
+## `/RMG/Generator/FromFile/`
+
+Commands for controlling reading event data from file
+
+
+**Commands:**
+
+* `FileName` – Set name of the file containing vertex kinetics for the next run. See the documentation for a specification of the format.
+* `NtupleDirectory` – Change the default input directory/group for ntuples.
+
+### `/RMG/Generator/FromFile/FileName`
+
+Set name of the file containing vertex kinetics for the next run. See the documentation for a specification of the format.
+
+* **Parameter** – `filename`
+  * **Parameter type** – `s`
+  * **Omittable** – `False`
+* **Allowed states** – `PreInit Idle`
+
+### `/RMG/Generator/FromFile/NtupleDirectory`
 
 Change the default input directory/group for ntuples.
 

--- a/include/RMGGeneratorDecay0.hh
+++ b/include/RMGGeneratorDecay0.hh
@@ -42,28 +42,33 @@ class RMGGeneratorDecay0 : public RMGVGenerator {
 
   public:
 
-    // This matches the BxDecay0 numbering, shifted by 1 as BxDecay0 starts counting at 1.
+    /**
+     * @enum Process
+     * @brief Enumeration of nuclear decay processes supported by the generator.
+     *
+     * This matches the BxDecay0 numbering, shifted by 1 as BxDecay0 starts counting at 1.
+     */
     enum class Process {
-      k0vbb,           // neutrinoless double beta decay
-      k0vbb_lambda_0,  // 0+ -> 0+ {2n} with RHC lambda
-      k0vbb_lambda_02, // 0+ -> 0+, 2+ {N*} with RHC lambda
-      k2vbb,           // 2 neutrino double beta decay
-      k0vbb_M1,        // 0+ -> 0+ {2n} (Majoron, SI=1)
-      k0vbb_M2,        // 0+ -> 0+ {2n} (Majoron, SI=2)
-      k0vbb_M3,        // 0+ -> 0+ {2n} (Majoron, SI=3)
-      k0vbb_M7,        // 0+ -> 0+ {2n} (Majoron, SI=7)
-      k0vbb_lambda_2,  // 0+ -> 2+ {2n} with RHC lambda
-      k2vbb_2,         // 0+ -> 2+ {2n}, {N*}
-      k0vkb,           // EC + beta+  0+ -> 0+, 2+
-      k2vkb,           // EC + beta+  0+ -> 0+, 2+
-      k0v2k,           // double EC  0+ -> 0+, 2+
-      k2v2k,           // double EC  0+ -> 0+, 2+
-      k2vbb_bos0,      //  0+ -> 0+ with bosonic neutrinos
-      k2vbb_bos2,      // 0+ -> 2+ with bosonic neutrinos
-      k0vbb_eta_s,     // 0+ -> 0+ with RHC eta simplified expression
-      k0vbb_eta_nmes,  //  0+ -> 0+ with RHC eta and specific NMEs
-      k2vbb_lv,        // 0+ -> 0+ with Lorentz violation
-      k0v4b            // 0+ -> 0+ Quadruple beta decay
+      /** @brief neutrinoless double beta decay */ k0vbb = 1,
+      /** @brief 0+ -> 0+ {2n} with RHC lambda */ k0vbb_lambda_0 = 2,
+      /** @brief 0+ -> 0+, 2+ {N*} with RHC lambda */ k0vbb_lambda_02 = 3,
+      /** @brief 2 neutrino double beta decay */ k2vbb = 4,
+      /** @brief 0+ -> 0+ {2n} (Majoron, SI=1) */ k0vbb_M1 = 5,
+      /** @brief 0+ -> 0+ {2n} (Majoron, SI=2) */ k0vbb_M2 = 6,
+      /** @brief 0+ -> 0+ {2n} (Majoron, SI=3) */ k0vbb_M3 = 7,
+      /** @brief 0+ -> 0+ {2n} (Majoron, SI=7) */ k0vbb_M7 = 8,
+      /** @brief 0+ -> 2+ {2n} with RHC lambda */ k0vbb_lambda_2 = 9,
+      /** @brief 0+ -> 2+ {2n}, {N*} */ k2vbb_2 = 10,
+      /** @brief EC + beta+  0+ -> 0+, 2+ */ k0vkb = 11,
+      /** @brief EC + beta+  0+ -> 0+, 2+ */ k2vkb = 12,
+      /** @brief double EC  0+ -> 0+, 2+ */ k0v2k = 13,
+      /** @brief double EC  0+ -> 0+, 2+ */ k2v2k = 14,
+      /** @brief 0+ -> 0+ with bosonic neutrinos */ k2vbb_bos0 = 15,
+      /** @brief 0+ -> 2+ with bosonic neutrinos */ k2vbb_bos2 = 16,
+      /** @brief 0+ -> 0+ with RHC eta simplified expression */ k0vbb_eta_s = 17,
+      /** @brief 0+ -> 0+ with RHC eta and specific NMEs */ k0vbb_eta_nmes = 18,
+      /** @brief 0+ -> 0+ with Lorentz violation */ k2vbb_lv = 19,
+      /** @brief 0+ -> 0+ Quadruple beta decay */ k0v4b = 20
     };
 
     /** @brief Constructor that links the BxDecay0 generator action to remage.
@@ -88,14 +93,12 @@ class RMGGeneratorDecay0 : public RMGVGenerator {
      *  @details Only does something if any remage set up command was used ( @c fUpdateSeeds is true).
      */
     void BeginOfRunAction(const G4Run*) override;
-    inline void EndOfRunAction(const G4Run*) override {}
+    void EndOfRunAction(const G4Run*) override {}
 
     /** @brief Sets BxDecay0 to run in background mode and sets the specific isotope.
      *  @param isotope The isotope to set (e.g. "Co60").
      */
     void SetBackground(std::string);
-
-    void SetUpdateSeeds(bool value) { fUpdateSeeds = value; }
 
 
   private:

--- a/include/RMGGeneratorDecay0.hh
+++ b/include/RMGGeneratorDecay0.hh
@@ -29,6 +29,15 @@ namespace bxdecay0_g4 {
 }
 
 class G4Event;
+/** @brief Integration of the BxDecay0 generator into remage.
+ *
+ *  This class links the BxDecay0 primary generator action with the remage vertex generator,
+ *  allowing the simulation of various decay processes.
+ *
+ *  Additionally it offers
+ *  more convenient commands to set the generator mode and process by
+ *  writing into the BxDecay0 configuration interface.
+ */
 class RMGGeneratorDecay0 : public RMGVGenerator {
 
   public:
@@ -57,6 +66,10 @@ class RMGGeneratorDecay0 : public RMGVGenerator {
       k0v4b            // 0+ -> 0+ Quadruple beta decay
     };
 
+    /** @brief Constructor that links the BxDecay0 generator action to remage.
+     *  @param prim_gen Pointer to the remage primary vertex generator.
+     *  @details  BxDecay0's primary generator action will own the pointer
+     */
     RMGGeneratorDecay0(RMGVVertexGenerator* prim_gen);
     RMGGeneratorDecay0() = delete;
     ~RMGGeneratorDecay0();
@@ -66,12 +79,20 @@ class RMGGeneratorDecay0 : public RMGVGenerator {
     RMGGeneratorDecay0(RMGGeneratorDecay0&&) = delete;
     RMGGeneratorDecay0& operator=(RMGGeneratorDecay0&&) = delete;
 
+    /** @brief Calls to @c fDecay0G4Generator to generate the primary for the event.
+     */
     void GeneratePrimaries(G4Event*) override;
     void SetParticlePosition(G4ThreeVector) override{};
 
+    /** @brief Updates the seed and configuration at the beginning of each run.
+     *  @details Only does something if any remage set up command was used ( @c fUpdateSeeds is true).
+     */
     void BeginOfRunAction(const G4Run*) override;
     inline void EndOfRunAction(const G4Run*) override {}
 
+    /** @brief Sets BxDecay0 to run in background mode and sets the specific isotope.
+     *  @param isotope The isotope to set (e.g. "Co60").
+     */
     void SetBackground(std::string);
 
     void SetUpdateSeeds(bool value) { fUpdateSeeds = value; }
@@ -84,9 +105,16 @@ class RMGGeneratorDecay0 : public RMGVGenerator {
     std::unique_ptr<G4GenericMessenger> fMessenger = nullptr;
     void DefineCommands();
 
+    /** @brief Sets whether the generator should update the seed and configuration at the beginning of a run.
+     *  Should only be true if the user has used a remage command to set the generator mode.
+     */
     bool fUpdateSeeds = false;
 
-    // Nested messenger class
+    /** @brief Nested messenger class to handle the more complex dbd command for the BxDecay0
+     * generator. This class allows setting the isotope, process, and energy level for the double
+     * beta decay mode. The energy level is optional and the process is specified from a predefined
+     * set of processes instead as an integer.
+     */
     class BxMessenger : public G4UImessenger {
       public:
 

--- a/include/RMGGeneratorDecay0.hh
+++ b/include/RMGGeneratorDecay0.hh
@@ -33,9 +33,28 @@ class RMGGeneratorDecay0 : public RMGVGenerator {
 
   public:
 
-    enum class DecayMode {
-      k2vbb,
-      k0vbb
+    // This matches the BxDecay0 numbering, shifted by 1 as BxDecay0 starts counting at 1.
+    enum class Process {
+      k0vbb,           // neutrinoless double beta decay
+      k0vbb_lambda_0,  // 0+ -> 0+ {2n} with RHC lambda
+      k0vbb_lambda_02, // 0+ -> 0+, 2+ {N*} with RHC lambda
+      k2vbb,           // 2 neutrino double beta decay
+      k0vbb_M1,        // 0+ -> 0+ {2n} (Majoron, SI=1)
+      k0vbb_M2,        // 0+ -> 0+ {2n} (Majoron, SI=2)
+      k0vbb_M3,        // 0+ -> 0+ {2n} (Majoron, SI=3)
+      k0vbb_M7,        // 0+ -> 0+ {2n} (Majoron, SI=7)
+      k0vbb_lambda_2,  // 0+ -> 2+ {2n} with RHC lambda
+      k2vbb_2,         // 0+ -> 2+ {2n}, {N*}
+      k0vkb,           // EC + beta+  0+ -> 0+, 2+
+      k2vkb,           // EC + beta+  0+ -> 0+, 2+
+      k0v2k,           // double EC  0+ -> 0+, 2+
+      k2v2k,           // double EC  0+ -> 0+, 2+
+      k2vbb_bos0,      //  0+ -> 0+ with bosonic neutrinos
+      k2vbb_bos2,      // 0+ -> 2+ with bosonic neutrinos
+      k0vbb_eta_s,     // 0+ -> 0+ with RHC eta simplified expression
+      k0vbb_eta_nmes,  //  0+ -> 0+ with RHC eta and specific NMEs
+      k2vbb_lv,        // 0+ -> 0+ with Lorentz violation
+      k0v4b            // 0+ -> 0+ Quadruple beta decay
     };
 
     RMGGeneratorDecay0(RMGVVertexGenerator* prim_gen);
@@ -50,21 +69,41 @@ class RMGGeneratorDecay0 : public RMGVGenerator {
     void GeneratePrimaries(G4Event*) override;
     void SetParticlePosition(G4ThreeVector) override{};
 
+    void BeginOfRunAction(const G4Run*) override;
+    inline void EndOfRunAction(const G4Run*) override {}
+
+    void SetBackground(std::string);
+
+    void SetUpdateSeeds(bool value) { fUpdateSeeds = value; }
+
+
   private:
 
     std::unique_ptr<bxdecay0_g4::PrimaryGeneratorAction> fDecay0G4Generator;
 
     std::unique_ptr<G4GenericMessenger> fMessenger = nullptr;
     void DefineCommands();
-    void SetMode(std::string mode);
 
-    DecayMode fDecayMode = DecayMode::k2vbb;
-    // BxDecay0 wants G4 variables
-    G4String nuclide;
-    long seed;
-    G4int dbd_mode;
-    G4int dbd_level;
-    G4bool debug;
+    bool fUpdateSeeds = false;
+
+    // Nested messenger class
+    class BxMessenger : public G4UImessenger {
+      public:
+
+        BxMessenger(RMGGeneratorDecay0* gen);
+        ~BxMessenger();
+
+        void SetNewValue(G4UIcommand* command, G4String newValues) override;
+
+      private:
+
+        RMGGeneratorDecay0* fGen;
+        G4UIcommand* fGeneratorCmd;
+
+        void GeneratorCmd(const std::string& parameters);
+    };
+
+    std::unique_ptr<BxMessenger> fUIMessenger;
 };
 
 #endif

--- a/include/RMGGeneratorDecay0.hh
+++ b/include/RMGGeneratorDecay0.hh
@@ -61,7 +61,7 @@ class RMGGeneratorDecay0 : public RMGVGenerator {
     DecayMode fDecayMode = DecayMode::k2vbb;
     // BxDecay0 wants G4 variables
     G4String nuclide;
-    G4int seed;
+    long seed;
     G4int dbd_mode;
     G4int dbd_level;
     G4bool debug;

--- a/include/RMGGeneratorDecay0.hh
+++ b/include/RMGGeneratorDecay0.hh
@@ -18,6 +18,7 @@
 
 #include <memory>
 
+#include "G4GenericMessenger.hh"
 #include "G4ThreeVector.hh"
 
 #include "RMGVGenerator.hh"
@@ -31,6 +32,11 @@ class G4Event;
 class RMGGeneratorDecay0 : public RMGVGenerator {
 
   public:
+
+    enum class DecayMode {
+      k2vbb,
+      k0vbb
+    };
 
     RMGGeneratorDecay0(RMGVVertexGenerator* prim_gen);
     RMGGeneratorDecay0() = delete;
@@ -47,6 +53,18 @@ class RMGGeneratorDecay0 : public RMGVGenerator {
   private:
 
     std::unique_ptr<bxdecay0_g4::PrimaryGeneratorAction> fDecay0G4Generator;
+
+    std::unique_ptr<G4GenericMessenger> fMessenger = nullptr;
+    void DefineCommands();
+    void SetMode(std::string mode);
+
+    DecayMode fDecayMode = DecayMode::k2vbb;
+    // BxDecay0 wants G4 variables
+    G4String nuclide;
+    G4int seed;
+    G4int dbd_mode;
+    G4int dbd_level;
+    G4bool debug;
 };
 
 #endif

--- a/include/RMGManager.hh
+++ b/include/RMGManager.hh
@@ -90,7 +90,7 @@ class RMGManager {
     void Run();
 
     void SetRandEngine(std::string name);
-    void SetRandEngineSeed(long seed);
+    void SetRandEngineSeed(int seed);
     void SetRandEngineInternalSeed(int index);
     void SetRandSystemEntropySeed();
     bool ApplyRandEngineForCurrentThread();

--- a/src/RMGGeneratorDecay0.cc
+++ b/src/RMGGeneratorDecay0.cc
@@ -65,12 +65,34 @@ void RMGGeneratorDecay0::SetMode(std::string mode) {
   } else {
     RMGLog::Out(RMGLog::error, "Unknown decay mode");
   }
-  seed = static_cast<G4int>(G4UniformRand() * std::numeric_limits<G4int>::max());
-  debug = false;
+
+  seed = CLHEP::HepRandom::getTheSeed();
+
+  // Sanity check
+  if (seed <= 0) {
+    RMGLog::Out(RMGLog::error, "Seed seems invalid or uninitialized. Setting seed to 0.");
+    seed = 0;
+  }
+
+  // This should never occur on most systems, as the only way is through the internal CLHEP table
+  // and the values there are all below the max int32.
+  if (seed > std::numeric_limits<int>::max()) {
+    int new_seed = seed - std::numeric_limits<int>::max();
+    RMGLog::Out(
+        RMGLog::warning,
+        "Seed ",
+        seed,
+        " is too large for BxDecay0. Largest possible seed is ",
+        std::numeric_limits<int>::max(),
+        ". Setting seed to ",
+        new_seed
+    );
+    seed = new_seed;
+  }
 
   bxdecay0_g4::PrimaryGeneratorAction::ConfigurationInterface& configInt = fDecay0G4Generator
                                                                                ->GrabConfiguration();
-
+  debug = false;
   configInt.reset_mdl();
   configInt.decay_category = "dbd";
   configInt.nuclide = nuclide;

--- a/src/RMGGeneratorDecay0.cc
+++ b/src/RMGGeneratorDecay0.cc
@@ -50,75 +50,129 @@ void RMGGeneratorDecay0::GeneratePrimaries(G4Event* event) {
   fDecay0G4Generator->GeneratePrimaries(event);
 }
 
-void RMGGeneratorDecay0::SetMode(std::string mode) {
-  try {
-    fDecayMode = RMGTools::ToEnum<RMGGeneratorDecay0::DecayMode>(mode, "decay mode");
-  } catch (const std::bad_cast&) { return; }
-  if (fDecayMode == DecayMode::k2vbb) {
-    nuclide = "Ge76";
-    dbd_mode = 4;
-    dbd_level = 0;
-  } else if (fDecayMode == DecayMode::k0vbb) {
-    nuclide = "Ge76";
-    dbd_mode = 1;
-    dbd_level = 0;
-  } else {
-    RMGLog::Out(RMGLog::error, "Unknown decay mode");
+void RMGGeneratorDecay0::BeginOfRunAction(const G4Run*) {
+  // Technically the user can change the seed at any time, so we have to always update.
+  // But only actually update the seed once the user used a RMGGeneratorDecay0 command.
+  if (fUpdateSeeds) {
+    long seed = CLHEP::HepRandom::getTheSeed();
+    // Sanity check
+    if (seed <= 0) {
+      RMGLog::Out(
+          RMGLog::error,
+          "CLHEP seed seems invalid or uninitialized. Setting BxDecay0 seed to 0."
+      );
+      seed = 0;
+    }
+
+    // This should never occur on most systems, as the only way is through the internal CLHEP table
+    // and the values there are all below the max int32.
+    if (seed > std::numeric_limits<int>::max()) {
+      int new_seed = seed - std::numeric_limits<int>::max();
+      RMGLog::Out(
+          RMGLog::warning,
+          "Seed ",
+          seed,
+          " is too large for BxDecay0. Largest possible seed is ",
+          std::numeric_limits<int>::max(),
+          ". Setting BxDecay0 seed to ",
+          new_seed
+      );
+      seed = new_seed;
+    }
+
+    bxdecay0_g4::PrimaryGeneratorAction::ConfigurationInterface&
+        configInt = fDecay0G4Generator->GrabConfiguration();
+    configInt.seed = seed;
+    RMGLog::Out(RMGLog::debug, "BxDecay0 generator: seed set to ", seed);
+    fDecay0G4Generator->SetConfigHasChanged(true);
   }
+}
 
-  seed = CLHEP::HepRandom::getTheSeed();
-
-  // Sanity check
-  if (seed <= 0) {
-    RMGLog::Out(RMGLog::error, "Seed seems invalid or uninitialized. Setting seed to 0.");
-    seed = 0;
-  }
-
-  // This should never occur on most systems, as the only way is through the internal CLHEP table
-  // and the values there are all below the max int32.
-  if (seed > std::numeric_limits<int>::max()) {
-    int new_seed = seed - std::numeric_limits<int>::max();
-    RMGLog::Out(
-        RMGLog::warning,
-        "Seed ",
-        seed,
-        " is too large for BxDecay0. Largest possible seed is ",
-        std::numeric_limits<int>::max(),
-        ". Setting seed to ",
-        new_seed
-    );
-    seed = new_seed;
-  }
-
+void RMGGeneratorDecay0::SetBackground(std::string isotope) {
+  RMGLog::Out(RMGLog::debug, "Setting BxDecay0 background mode with isotope: ", isotope);
   bxdecay0_g4::PrimaryGeneratorAction::ConfigurationInterface& configInt = fDecay0G4Generator
                                                                                ->GrabConfiguration();
-  debug = false;
-  configInt.reset_mdl();
-  configInt.decay_category = "dbd";
-  configInt.nuclide = nuclide;
-  configInt.seed = seed;
-  configInt.dbd_mode = dbd_mode;
-  configInt.dbd_level = dbd_level;
-  configInt.debug = debug;
-  fDecay0G4Generator->SetConfigHasChanged(true);
+  configInt.reset_base();
+  configInt.decay_category = "background";
+  configInt.nuclide = isotope;
+  configInt.debug = false; // If we want a debug mode, we need to add a command for it
+  SetUpdateSeeds(true);    // The seed and config update should now be done in BeginOfRunAction
 }
 
 void RMGGeneratorDecay0::DefineCommands() {
 
-  // NOTE: SetUnit(Category) is not thread-safe
-
   fMessenger = std::make_unique<G4GenericMessenger>(
       this,
-      "/RMG/Generator/Decay0/",
+      "/RMG/Generator/BxDecay0/",
       "Commands for controlling the BxDecay0 generator"
   );
 
-  fMessenger->DeclareMethod("Mode", &RMGGeneratorDecay0::SetMode)
-      .SetGuidance("Set the mode of the BxDecay0 generator.")
-      .SetParameterName("mode", false)
-      .SetCandidates(RMGTools::GetCandidates<RMGGeneratorDecay0::DecayMode>())
+  // Need an additional command because both modes expect different parameters.
+  fMessenger->DeclareMethod("background", &RMGGeneratorDecay0::SetBackground)
+      .SetGuidance("Set the isotope for the background mode of the BxDecay0 generator. E.g. 'Co60'")
+      .SetParameterName("isotope", false) // Do we want to add an enum for every supported isotope?
       .SetToBeBroadcasted(true)
       .SetStates(G4State_PreInit, G4State_Idle);
+
+  // Make one macro command for the dbd mode.
+  fUIMessenger = std::make_unique<BxMessenger>(this);
+}
+
+RMGGeneratorDecay0::BxMessenger::BxMessenger(RMGGeneratorDecay0* gen) : fGen(gen) {
+
+
+  fGeneratorCmd = new G4UIcommand("/RMG/Generator/BxDecay0/dbd", this);
+  fGeneratorCmd
+      ->SetGuidance("Set the isotope, process and energy level for the double beta decay mode of the BxDecay0 generator");
+
+  auto isotope = new G4UIparameter("isotope", 's', false);
+  isotope->SetGuidance(
+      "Set the isotope for the double beta decay"
+  ); // Do we want to add an enum for every supported isotope?
+  fGeneratorCmd->SetParameter(isotope);
+
+  auto process = new G4UIparameter("process", 's', false);
+  process->SetGuidance("Name the decay process you want to simulate");
+  process->SetParameterCandidates(RMGTools::GetCandidates<RMGGeneratorDecay0::Process>().c_str());
+  fGeneratorCmd->SetParameter(process);
+
+  auto level = new G4UIparameter("level", 'i', false);
+  level->SetGuidance("Energy level of the daughter nucleus");
+  level->SetDefaultValue("0");
+  level->SetOmittable(true);
+  fGeneratorCmd->SetParameter(level);
+
+  fGeneratorCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
+}
+
+RMGGeneratorDecay0::BxMessenger::~BxMessenger() { delete fGeneratorCmd; }
+
+void RMGGeneratorDecay0::BxMessenger::SetNewValue(G4UIcommand* command, G4String newValues) {
+  if (command == fGeneratorCmd) GeneratorCmd(newValues); // This way it is scalable to more commands
+}
+
+void RMGGeneratorDecay0::BxMessenger::GeneratorCmd(const std::string& parameters) {
+  G4Tokenizer next(parameters);
+
+  auto isotope = next();
+  auto proc = next();
+  auto level = std::stoi(next());
+  RMGLog::Out(RMGLog::debug, "BxDecay0 generator: isotope = ", isotope, ", proc = ", proc, ", level = ", level);
+  Process p = RMGGeneratorDecay0::Process::k2vbb;
+  try {
+    p = RMGTools::ToEnum<RMGGeneratorDecay0::Process>(proc, "process");
+  } catch (const std::bad_cast&) { return; }
+
+  bxdecay0_g4::PrimaryGeneratorAction::ConfigurationInterface& configInt = fGen->fDecay0G4Generator
+                                                                               ->GrabConfiguration();
+  configInt.reset_mdl();
+  configInt.decay_category = "dbd";
+  configInt.nuclide = isotope;
+  configInt.dbd_mode = static_cast<int>(p) +
+                       1; // The enum starts at 0, but BxDecay0 starts counting at 1
+  configInt.dbd_level = level;
+  configInt.debug = false;    // If we want a debug mode, we need to add it to the command
+  fGen->SetUpdateSeeds(true); // The seed and config update should now be done in BeginOfRunAction
 }
 
 // vim: tabstop=2 shiftwidth=2 expandtab

--- a/src/RMGGeneratorDecay0.cc
+++ b/src/RMGGeneratorDecay0.cc
@@ -15,9 +15,15 @@
 
 #include "RMGGeneratorDecay0.hh"
 
+#include <limits>
+
+#include "Randomize.hh"
+
 #include "RMGConfig.hh"
 #include "RMGLog.hh"
 #include "RMGManager.hh"
+#include "RMGTools.hh"
+
 #if RMG_HAS_BXDECAY0
 #include "bxdecay0_g4/primary_generator_action.hh"
 #endif
@@ -34,6 +40,7 @@ RMGGeneratorDecay0::RMGGeneratorDecay0(RMGVVertexGenerator* prim_gen) : RMGVGene
   fDecay0G4Generator = std::make_unique<bxdecay0_g4::PrimaryGeneratorAction>();
   // NOTE: BxDecay0's primary generator action will own the pointer
   fDecay0G4Generator->SetVertexGenerator(prim_gen);
+  this->DefineCommands();
 }
 
 // Need non-inline, i.e. not in header/class body, destructor to hide BXDecay0 from consumers
@@ -41,6 +48,55 @@ RMGGeneratorDecay0::~RMGGeneratorDecay0() = default; // NOLINT
 
 void RMGGeneratorDecay0::GeneratePrimaries(G4Event* event) {
   fDecay0G4Generator->GeneratePrimaries(event);
+}
+
+void RMGGeneratorDecay0::SetMode(std::string mode) {
+  try {
+    fDecayMode = RMGTools::ToEnum<RMGGeneratorDecay0::DecayMode>(mode, "decay mode");
+  } catch (const std::bad_cast&) { return; }
+  if (fDecayMode == DecayMode::k2vbb) {
+    nuclide = "Ge76";
+    dbd_mode = 4;
+    dbd_level = 0;
+  } else if (fDecayMode == DecayMode::k0vbb) {
+    nuclide = "Ge76";
+    dbd_mode = 1;
+    dbd_level = 0;
+  } else {
+    RMGLog::Out(RMGLog::error, "Unknown decay mode");
+  }
+  seed = static_cast<G4int>(G4UniformRand() * std::numeric_limits<G4int>::max());
+  debug = false;
+
+  bxdecay0_g4::PrimaryGeneratorAction::ConfigurationInterface& configInt = fDecay0G4Generator
+                                                                               ->GrabConfiguration();
+
+  configInt.reset_mdl();
+  configInt.decay_category = "dbd";
+  configInt.nuclide = nuclide;
+  configInt.seed = seed;
+  configInt.dbd_mode = dbd_mode;
+  configInt.dbd_level = dbd_level;
+  configInt.debug = debug;
+  fDecay0G4Generator->SetConfigHasChanged(true);
+}
+
+void RMGGeneratorDecay0::DefineCommands() {
+
+  // NOTE: SetUnit(Category) is not thread-safe
+
+  fMessenger = std::make_unique<G4GenericMessenger>(
+      this,
+      "/RMG/Generator/Decay0/",
+      "Commands for controlling the BxDecay0 generator"
+  );
+
+  fMessenger->DeclareMethod("Mode", &RMGGeneratorDecay0::SetMode)
+      .SetGuidance("Set the mode of the BxDecay0 generator.")
+      .SetParameterName("mode", false)
+      .SetCandidates(RMGTools::GetCandidates<RMGGeneratorDecay0::DecayMode>())
+      .SetToBeBroadcasted(true)
+      .SetStates(G4State_PreInit, G4State_Idle);
 }
 
 // vim: tabstop=2 shiftwidth=2 expandtab

--- a/src/RMGManager.cc
+++ b/src/RMGManager.cc
@@ -288,15 +288,16 @@ void RMGManager::CheckRandEngineMTState() {
   );
 }
 
-void RMGManager::SetRandEngineSeed(long seed) {
+void RMGManager::SetRandEngineSeed(int seed) {
   CheckRandEngineMTState();
-  if (seed >= std::numeric_limits<long>::max()) {
+  // this should actually never occur, as the Geant4 messenger should check this
+  if (seed >= std::numeric_limits<int>::max()) {
     RMGLog::Out(
         RMGLog::error,
         "Seed ",
         seed,
         " is too large. Largest possible seed is ",
-        std::numeric_limits<long>::max(),
+        std::numeric_limits<int>::max(),
         ". Setting seed to 0."
     );
     CLHEP::HepRandom::setTheSeed(0);

--- a/src/remage-doc-dump.cc
+++ b/src/remage-doc-dump.cc
@@ -23,6 +23,7 @@
 #include "G4UIcommandTree.hh"
 #include "G4UImanager.hh"
 
+#include "RMGConfig.hh"
 #include "RMGGeneratorCosmicMuons.hh"
 #if RMG_HAS_BXDECAY0
 #include "RMGGeneratorDecay0.hh"
@@ -57,9 +58,15 @@ void init_extra() {
   new RMGIsotopeFilterScheme();
   new RMGTrackOutputScheme();
   new RMGParticleFilterScheme();
+
   // confinments
   new RMGVertexConfinement();
+#if RMG_HAS_BXDECAY0
   auto vertex_gen = new RMGVertexFromFile();
+#else
+  new RMGVertexFromFile(); // So the compiler does not complain about unused variable.
+#endif
+
   // generators
   new RMGGeneratorMUSUNCosmicMuons();
   new RMGGeneratorCosmicMuons();

--- a/src/remage-doc-dump.cc
+++ b/src/remage-doc-dump.cc
@@ -24,7 +24,9 @@
 #include "G4UImanager.hh"
 
 #include "RMGGeneratorCosmicMuons.hh"
+#if RMG_HAS_BXDECAY0
 #include "RMGGeneratorDecay0.hh"
+#endif
 #include "RMGGeneratorFromFile.hh"
 #include "RMGGeneratorMUSUNCosmicMuons.hh"
 #include "RMGGermaniumOutputScheme.hh"
@@ -61,7 +63,9 @@ void init_extra() {
   // generators
   new RMGGeneratorMUSUNCosmicMuons();
   new RMGGeneratorCosmicMuons();
+#if RMG_HAS_BXDECAY0
   new RMGGeneratorDecay0(vertex_gen); // needs a vertex generator
+#endif
   new RMGGeneratorFromFile();
 }
 

--- a/src/remage-doc-dump.cc
+++ b/src/remage-doc-dump.cc
@@ -24,6 +24,7 @@
 #include "G4UImanager.hh"
 
 #include "RMGGeneratorCosmicMuons.hh"
+#include "RMGGeneratorDecay0.hh"
 #include "RMGGeneratorFromFile.hh"
 #include "RMGGeneratorMUSUNCosmicMuons.hh"
 #include "RMGGermaniumOutputScheme.hh"
@@ -54,13 +55,14 @@ void init_extra() {
   new RMGIsotopeFilterScheme();
   new RMGTrackOutputScheme();
   new RMGParticleFilterScheme();
+  // confinments
+  new RMGVertexConfinement();
+  auto vertex_gen = new RMGVertexFromFile();
   // generators
   new RMGGeneratorMUSUNCosmicMuons();
   new RMGGeneratorCosmicMuons();
+  new RMGGeneratorDecay0(vertex_gen); // needs a vertex generator
   new RMGGeneratorFromFile();
-  // confinments
-  new RMGVertexConfinement();
-  new RMGVertexFromFile();
 }
 
 void list_tree(G4UIcommandTree* tree);


### PR DESCRIPTION
So this adds the simple macro command `/RMG/Generator/Decay0/Mode` to remage with the two options `2vbb` and `0vbb`.

These options can be expanded easily. (Or change the name to `/RMG/Generator/Decay/Mode` if thats better)


The simulation will always use the last specified command. So in case of:
```console
/RMG/Generator/Select BxDecay0
/RMG/Generator/Decay0/Mode 2vbb
/bxdecay0/generator/dbd Xe136 2345 4 0
```
Xe-136 will be simulated and vice versa.
If you want some tests on this for the CI i am not sure, anyone has ideas what tests we would like?

