### PR TITLE
Add BxDecay0 docs to the user manual

### DIFF
--- a/docs/manual/extend.md
+++ b/docs/manual/extend.md
@@ -11,15 +11,6 @@ find_package(remage REQUIRED)
 target_link_libraries(myapp PRIVATE RMG::remage)
 ```
 
-:::{note}
-
-When updating from older _remage_ versions you might encounter some issues with
-remnants of old dependencies. In this case fully delete your current _remage_
-installation and re-install into a clean folder, as the install process itself
-will not remove any files that are not on the list of to-be-installed files.
-
-:::
-
 ## Forwarding arguments
 
 The {cpp:class}`RMGManager` is crucial for any of your code to extend _remage_.

--- a/docs/manual/extend.md
+++ b/docs/manual/extend.md
@@ -11,6 +11,15 @@ find_package(remage REQUIRED)
 target_link_libraries(myapp PRIVATE RMG::remage)
 ```
 
+:::{note}
+
+When updating from older _remage_ versions you might encounter some issues with
+remnants of old dependencies. In this case fully delete your current _remage_
+installation and re-install into a clean folder, as the install process itself
+will not remove any files that are not on the list of to-be-installed files.
+
+:::
+
 ## Forwarding arguments
 
 The {cpp:class}`RMGManager` is crucial for any of your code to extend _remage_.

--- a/docs/manual/generators.md
+++ b/docs/manual/generators.md
@@ -206,10 +206,16 @@ The second macro command is used to generate background physics with _bxdecay0_.
 The command <project:../rmg-commands.md#rmggeneratorbxdecay0background> takes
 only a single string as parameter, which should be the name of the isotope.
 Again all isotope candidates are listed
-[here](project:../rmg-commands.md#rmggeneratorbxdecay0background).
+[here](project:../rmg-commands.md#rmggeneratorbxdecay0background). Using these
+we can for example simulate a $^{60}$Co background source:
 
-_remage_ will forward the current seed of Geant4 to _bxdecay0_. This means that
-if any seed is specified using the
+```
+/RMG/Generator/Select BxDecay0
+/RMG/Generator/BxDecay0/background Co60
+```
+
+The current seed of Geant4 will be forwarded to _bxdecay0_. This means that if
+any seed is specified using the
 <project:../rmg-commands.md#rmgmanagerrandomization> commands, that seed will be
 forwarded to _bxdecay0_.
 

--- a/docs/manual/generators.md
+++ b/docs/manual/generators.md
@@ -188,10 +188,11 @@ generator macro commands are still available to the user, the _remage_ commands
 offer a simpler and more intuitive alternative.
 
 The macro command to generate double beta decay physics
-<project:../rmg-commands.md#rmggeneratorbxdecay0dbd> expects the isotope name,
-the name of the process you want to simulate (like `2vbb` or `0vbb`) and an
-optional level for the daughter nucleus. All available isotopes and processes
-are listed [here](project:../rmg-commands.md#rmggeneratorbxdecay0dbd). The
+<project:../rmg-commands.md#rmggeneratorbxdecay0doublebetadecay> expects the
+isotope name, the name of the process you want to simulate (like `2vbb` or
+`0vbb`) and an optional level for the daughter nucleus. All available isotopes
+and processes are listed
+[here](project:../rmg-commands.md#rmggeneratorbxdecay0doublebetadecay). The
 nuclear level defaults to ground state and can therefore be omitted in most
 cases.
 
@@ -200,7 +201,7 @@ state of $^{76}$Ge with:
 
 ```
 /RMG/Generator/Select BxDecay0
-/RMG/Generator/BxDecay0/dbd Ge76 2vbb
+/RMG/Generator/BxDecay0/DoubleBetaDecay Ge76 2vbb
 ```
 
 The second macro command is used to generate other radioactive decay physics
@@ -213,7 +214,7 @@ we can for example simulate a $^{60}$Co background source:
 
 ```
 /RMG/Generator/Select BxDecay0
-/RMG/Generator/BxDecay0/background Co60
+/RMG/Generator/BxDecay0/Background Co60
 ```
 
 The current seed of Geant4 will be forwarded to _bxdecay0_. This means that if

--- a/docs/manual/generators.md
+++ b/docs/manual/generators.md
@@ -173,48 +173,59 @@ This mechanism can be used to select arbitrary sections of decay chains!
 
 To generate double beta decay physics we interface with the _bxdecay0_ package.
 This requires _remage_ to be build with _bxdecay0_ support see {ref}`install`.
-The only documentation for this extension is available
+The main documentation for this extension is available
 [here](https://github.com/BxCppDev/bxdecay0).
 
 The macro [command](project:../rmg-commands.md#rmggeneratorselect):
 
 `/RMG/Generator/Select BxDecay0`
 
-can be used to select the Decay0 generators.
+can be used to select the Decay0 generator.
 
-We can then use the _bxdecay0_ double beta decay generator macro commands to
-generate double beta decay physics. The macro command to generate double beta
-decay physics is:
+_remage_ adds two macro commands to control the generator, which should cover
+all required use cases. While the original _bxdecay0_ double beta decay
+generator macro commands are still available to the user, the _remage_ commands
+offer a simpler and more intuitive alternative.
 
-```
-/bxdecay0/generator/dbd ISOTOPE SEED MODE LEVEL
-```
-
-Where:
-
-- `ISOTOPE` (string): is the decaying nuclei,
-- `SEED` (int): is a random seed,
-- `MODE` (int): is an index the double beta decay mode labelling the decay type,
-  a table of implemented decay modes can be found in
-  [link](https://github.com/BxCppDev/bxdecay0/tree/develop?tab=readme-ov-file#list-of-supported-double-beta-decay-modes).
-- `LEVEL` (int): is a index of the energy level of the daughter nuclei, the list
-  of available levels are
-  [documented here](https://github.com/BxCppDev/bxdecay0/tree/develop?tab=readme-ov-file#list-of-daughter-nucleus-excited-states-in-double-beta-decay).
+The macro command to generate double beta decay physics
+<project:../rmg-commands.md#rmggeneratorbxdecay0dbd> expects the isotope name,
+the name of the process you want to simulate (like 2vbb or 0vbb) and an optional
+energy level for the daughter nucleus. All available isotopes and processes are
+listed [here](project:../rmg-commands.md#rmggeneratorbxdecay0dbd). The energy
+level defaults to zero and can therefore be omitted in most cases.
 
 For example we can generate two-neutrino double beta decay to the $0^+$ ground
 state of $^{76}$Ge with:
 
 ```
 /RMG/Generator/Select BxDecay0
-/bxdecay0/generator/dbd Ge76 1234 4 0
+/RMG/Generator/BxDecay0/dbd Ge76 2vbb
 ```
+
+The second macro command is used to generate background physics with _bxdecay0_.
+The command <project:../rmg-commands.md#rmggeneratorbxdecay0background> takes
+only a single string as parameter, which should be the name of the isotope.
+Again all isotope candidates are listed
+[here](project:../rmg-commands.md#rmggeneratorbxdecay0background).
+
+_remage_ will forward the current seed of Geant4 to _bxdecay0_. This means that
+if any seed is specified using the
+<project:../rmg-commands.md#rmgmanagerrandomization> commands, that seed will be
+forwarded to _bxdecay0_.
+
+:::{note}
+
+_bxdecay0_ accepts only `int` seed values, while Geant4 accepts `long` values.
+In case a Geant4 seed happens to be above the numerical limit of `int`, the
+forwarded seed will be reduced to `old_seed - std::numeric_limits<int>::max()`.
+
+:::
 
 :::{tip}
 
-- More information on the double beta decay commands can be obtained with
-  `/control/manual /bxdecay0/generator/dbd`
 - The verbosity of _bxdecay0_ can be increased with
-  `/bxdecay0/generator/verbosity LEVEL` where `LEVEL` is 0, 1, 2 and 3.
+  `/bxdecay0/generator/verbosity LEVEL` where `LEVEL` is 0, 1, 2 and 3. This
+  should work in combination with the _remage_ macro commands.
 
 :::
 

--- a/docs/manual/generators.md
+++ b/docs/manual/generators.md
@@ -180,7 +180,7 @@ The macro [command](project:../rmg-commands.md#rmggeneratorselect):
 
 `/RMG/Generator/Select BxDecay0`
 
-can be used to select the Decay0 generator.
+can be used to select the BxDecay0 generator.
 
 _remage_ adds two macro commands to control the generator, which should cover
 all required use cases. While the original _bxdecay0_ double beta decay
@@ -189,10 +189,11 @@ offer a simpler and more intuitive alternative.
 
 The macro command to generate double beta decay physics
 <project:../rmg-commands.md#rmggeneratorbxdecay0dbd> expects the isotope name,
-the name of the process you want to simulate (like 2vbb or 0vbb) and an optional
-energy level for the daughter nucleus. All available isotopes and processes are
-listed [here](project:../rmg-commands.md#rmggeneratorbxdecay0dbd). The energy
-level defaults to zero and can therefore be omitted in most cases.
+the name of the process you want to simulate (like `2vbb` or `0vbb`) and an
+optional level for the daughter nucleus. All available isotopes and processes
+are listed [here](project:../rmg-commands.md#rmggeneratorbxdecay0dbd). The
+nuclear level defaults to ground state and can therefore be omitted in most
+cases.
 
 For example we can generate two-neutrino double beta decay to the $0^+$ ground
 state of $^{76}$Ge with:
@@ -202,10 +203,11 @@ state of $^{76}$Ge with:
 /RMG/Generator/BxDecay0/dbd Ge76 2vbb
 ```
 
-The second macro command is used to generate background physics with _bxdecay0_.
-The command <project:../rmg-commands.md#rmggeneratorbxdecay0background> takes
-only a single string as parameter, which should be the name of the isotope.
-Again all isotope candidates are listed
+The second macro command is used to generate other radioactive decay physics
+with _bxdecay0_. The command
+<project:../rmg-commands.md#rmggeneratorbxdecay0background> takes only a single
+string as parameter, which should be the name of the isotope. Again all isotope
+candidates are listed
 [here](project:../rmg-commands.md#rmggeneratorbxdecay0background). Using these
 we can for example simulate a $^{60}$Co background source:
 
@@ -219,7 +221,7 @@ any seed is specified using the
 <project:../rmg-commands.md#rmgmanagerrandomization> commands, that seed will be
 forwarded to _bxdecay0_.
 
-:::{note}
+:::{warning}
 
 _bxdecay0_ accepts only `int` seed values, while Geant4 accepts `long` values.
 In case a Geant4 seed happens to be above the numerical limit of `int`, the

--- a/docs/manual/install.md
+++ b/docs/manual/install.md
@@ -53,6 +53,15 @@ $ cmake -DCMAKE_INSTALL_PREFIX=<unique prefix> ..
 $ make install
 ```
 
+:::{tip}
+
+When encountering any unexpected issues the first step should always be to
+remove the build folder and compile from scratch. The second step should be to
+additionally also remove the install folder and any traces of _remage_ to try
+the installation on a fresh system.
+
+:::
+
 ## Setting up Jupyter
 
 To set up a _remage_-aware Jupyter kernel, you only have to provide the correct

--- a/docs/manual/physicslist.md
+++ b/docs/manual/physicslist.md
@@ -6,6 +6,29 @@
 - optional components and options (hadronic, leptonic, optical)
 - production cuts and step limits
 - custom WLS optical process
+- custom Grabmayr gammacascades
 - simulating radioactive decay chains
 
 :::
+
+## optional components
+
+:::{todo}
+
+- optional components and options (hadronic, leptonic, optical)
+
+:::
+
+### hadronic physics options
+
+:::{todo}
+
+- hadronic physics options
+
+:::
+
+Geant4 changed the default time threshold for radioactive decays in the 11.2
+minor update to 1 year. _remage_ automatically reverts this change and sets the
+threshold to the old default of Geant4 before 11.2, being `1.0e+27 ns`. This
+threshold can be adjusted using the built-in command
+`/process/had/rdm/thresholdForVeryLongDecayTime` after `/run/initialize` .

--- a/docs/rmg-commands.md
+++ b/docs/rmg-commands.md
@@ -1813,12 +1813,12 @@ Commands for controlling the BxDecay0 generator
 
 **Commands:**
 
-* `background` – Set the isotope for the background mode of the BxDecay0 generator. E.g. 'Co60'
-* `dbd` – Set the isotope, process and energy level for the double beta decay mode of the BxDecay0 generator
+* `Background` – Set the isotope for the Background mode of the BxDecay0 generator. E.g. 'Co60'
+* `DoubleBetaDecay` – Set the isotope, process and energy level for the double beta decay mode of the BxDecay0 generator
 
-### `/RMG/Generator/BxDecay0/background`
+### `/RMG/Generator/BxDecay0/Background`
 
-Set the isotope for the background mode of the BxDecay0 generator. E.g. 'Co60'
+Set the isotope for the Background mode of the BxDecay0 generator. E.g. 'Co60'
 
 * **Parameter** – `isotope`
   * **Parameter type** – `s`
@@ -1826,7 +1826,7 @@ Set the isotope for the background mode of the BxDecay0 generator. E.g. 'Co60'
   * **Candidates** – `Ac228 Am241 Ar39 Ar42 As79+Se79m Bi207+Pb207m Bi208 Bi210 Bi212+Po212 Bi214+Po214 C14 Ca48+Sc48 Cd113 Co60 Cs136 Cs137+Ba137m Eu147 Eu152 Eu154 Gd146 Hf182 I126 I133 I134 I135 K40 K42 Kr81 Kr85 Mn54 Na22 P32 Pa231 Pa234m Pb210 Pb211 Pb212 Pb214 Po210 Po218 Ra226 Ra228 Rb87 Rh106 Rn222 Sb125 Sb126 Sb133 Sr90 Ta180m-B- Ta180m-EC Ta182 Te133 Te133m Te134 Th230 Th234 Tl207 Tl208 U234 U238 Xe129m Xe131m Xe133 Xe135 Y88 Y90 Zn65 Zr96+Nb96`
 * **Allowed states** – `PreInit Idle`
 
-### `/RMG/Generator/BxDecay0/dbd`
+### `/RMG/Generator/BxDecay0/DoubleBetaDecay`
 
 Set the isotope, process and energy level for the double beta decay mode of the BxDecay0 generator
 

--- a/include/RMGGeneratorDecay0.hh
+++ b/include/RMGGeneratorDecay0.hh
@@ -113,10 +113,10 @@ class RMGGeneratorDecay0 : public RMGVGenerator {
      */
     bool fUpdateSeeds = false;
 
-    /** @brief Nested messenger class to handle the more complex dbd command for the BxDecay0
-     * generator. This class allows setting the isotope, process, and energy level for the double
-     * beta decay mode. The energy level is optional and the process is specified from a predefined
-     * set of processes instead as an integer.
+    /** @brief Nested messenger class to handle the more complex double beta decay command for the
+     * BxDecay0 generator. This class allows setting the isotope, process, and energy level for the
+     * double beta decay mode. The energy level is optional and the process is specified from a
+     * predefined set of processes instead as an integer.
      */
     class BxMessenger : public G4UImessenger {
       public:

--- a/src/RMGGeneratorDecay0.cc
+++ b/src/RMGGeneratorDecay0.cc
@@ -110,21 +110,21 @@ void RMGGeneratorDecay0::DefineCommands() {
   std::string isot_cand;
   for (const auto& isot : bxdecay0::background_isotopes()) { isot_cand += std::string(isot) + ' '; }
   // Need an additional command because both modes expect different parameters.
-  fMessenger->DeclareMethod("background", &RMGGeneratorDecay0::SetBackground)
-      .SetGuidance("Set the isotope for the background mode of the BxDecay0 generator. E.g. 'Co60'")
+  fMessenger->DeclareMethod("Background", &RMGGeneratorDecay0::SetBackground)
+      .SetGuidance("Set the isotope for the Background mode of the BxDecay0 generator. E.g. 'Co60'")
       .SetParameterName("isotope", false)
       .SetCandidates(isot_cand)
       .SetToBeBroadcasted(true)
       .SetStates(G4State_PreInit, G4State_Idle);
 
-  // Make one macro command for the dbd mode.
+  // Make one macro command for the double beta decay mode.
   fUIMessenger = std::make_unique<BxMessenger>(this);
 }
 
 RMGGeneratorDecay0::BxMessenger::BxMessenger(RMGGeneratorDecay0* gen) : fGen(gen) {
 
 
-  fGeneratorCmd = new G4UIcommand("/RMG/Generator/BxDecay0/dbd", this);
+  fGeneratorCmd = new G4UIcommand("/RMG/Generator/BxDecay0/DoubleBetaDecay", this);
   fGeneratorCmd
       ->SetGuidance("Set the isotope, process and energy level for the double beta decay mode of the BxDecay0 generator");
 


### PR DESCRIPTION
-rework bxdecay docs 
-add note to extend for updating from old versions where remants of old dependencies might cause issues
-add hadronic decay time threshold info to physicslist. If i have time i can also do some more work on the physicslist part of the usermanual, although i am honestly no expert in what the difference between them is. I can atleast explain what options there are and how to choose