### PR TITLE
Fix issue 295 - update copyright headers

### DIFF
--- a/include/RMGGrabmayrGCReader.hh
+++ b/include/RMGGrabmayrGCReader.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Eric Esch <eric.esch@uni-tuebingen.de>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGHardwareMessenger.hh
+++ b/include/RMGHardwareMessenger.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Manuel Huber
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGIsotopeFilterScheme.hh
+++ b/include/RMGIsotopeFilterScheme.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2025 Eric Esch <eric.esch@uni-tuebingen.de>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGNeutronCaptureProcess.hh
+++ b/include/RMGNeutronCaptureProcess.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Eric Esch <eric.esch@uni-tuebingen.de>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGScintillatorDetector.hh
+++ b/include/RMGScintillatorDetector.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Manuel Huber
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGScintillatorOutputScheme.hh
+++ b/include/RMGScintillatorOutputScheme.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Manuel Huber
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGTrackOutputScheme.hh
+++ b/include/RMGTrackOutputScheme.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Manuel Huber
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGVertexOutputScheme.hh
+++ b/include/RMGVertexOutputScheme.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Manuel Huber
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGGeneratorMUSUNCosmicMuons.cc
+++ b/src/RMGGeneratorMUSUNCosmicMuons.cc
@@ -1,3 +1,15 @@
+// Copyright (C) 2024 Moritz Neuberger
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option) any
+// later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+// details.
+//
 #include "RMGGeneratorMUSUNCosmicMuons.hh"
 
 #include <cmath>

--- a/src/RMGGrabmayrGCReader.cc
+++ b/src/RMGGrabmayrGCReader.cc
@@ -1,4 +1,16 @@
-#include "RMGGrabmayrGCReader.hh"
+// Copyright (C) 2024 Eric Esch <eric.esch@uni-tuebingen.de>
+//
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option) any
+// later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+// details.
+//
 
 #include "G4Tokenizer.hh"
 #include "Randomize.hh"

--- a/src/RMGHardwareMessenger.cc
+++ b/src/RMGHardwareMessenger.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Manuel Huber
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGIsotopeFilterScheme.cc
+++ b/src/RMGIsotopeFilterScheme.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2025 Eric Esch <eric.esch@uni-tuebingen.de>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGNeutronCaptureProcess.cc
+++ b/src/RMGNeutronCaptureProcess.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Eric Esch <eric.esch@uni-tuebingen.de>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGScintillatorDetector.cc
+++ b/src/RMGScintillatorDetector.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Manuel Huber
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGScintillatorOutputScheme.cc
+++ b/src/RMGScintillatorOutputScheme.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Manuel Huber
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGStackingAction.cc
+++ b/src/RMGStackingAction.cc
@@ -1,3 +1,4 @@
+// Copyright (C) 2021 Luigi Pertoldi <gipert@pm.me>
 // Copyright (C) 2024 Manuel Huber
 //
 // This program is free software: you can redistribute it and/or modify it under

--- a/src/RMGTrackOutputScheme.cc
+++ b/src/RMGTrackOutputScheme.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Manuel Huber
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGVertexOutputScheme.cc
+++ b/src/RMGVertexOutputScheme.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Manuel Huber
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free


### PR DESCRIPTION
## Summary
- correct author info in various headers
- add missing license headers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684be860dc5c833080af58e18b6803f4