### PR TITLE
Update copyright headers

### DIFF
--- a/include/RMGAnalysisReader.hh
+++ b/include/RMGAnalysisReader.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Manuel Huber
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGConvertLH5.hh
+++ b/include/RMGConvertLH5.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Manuel Huber
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGDetectorHit.hh
+++ b/include/RMGDetectorHit.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Toby Dixon <toby.dixon.23@ucl.ac.uk>
+// Copyright (C) 2025 Toby Dixon <https://orcid.org/0000-0001-8787-6336>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGDetectorMetadata.hh
+++ b/include/RMGDetectorMetadata.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGEventAction.hh
+++ b/include/RMGEventAction.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGExceptionHandler.hh
+++ b/include/RMGExceptionHandler.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Manuel Huber
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGGeneratorCosmicMuons.hh
+++ b/include/RMGGeneratorCosmicMuons.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGGeneratorDecay0.hh
+++ b/include/RMGGeneratorDecay0.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGGeneratorFromFile.hh
+++ b/include/RMGGeneratorFromFile.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Manuel Huber
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGGeneratorG4Gun.hh
+++ b/include/RMGGeneratorG4Gun.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGGeneratorGPS.hh
+++ b/include/RMGGeneratorGPS.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGGeneratorMUSUNCosmicMuons.hh
+++ b/include/RMGGeneratorMUSUNCosmicMuons.hh
@@ -1,3 +1,19 @@
+// Copyright (C) 2024 Moritz Neuberger <https://orcid.org/0009-0001-8471-9076>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option) any
+// later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
 #ifndef _RMG_GENERATOR_MUSUN_COSMIC_MUONS_HH_
 #define _RMG_GENERATOR_MUSUN_COSMIC_MUONS_HH_
 

--- a/include/RMGGeneratorUtil.hh
+++ b/include/RMGGeneratorUtil.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGGermaniumDetector.hh
+++ b/include/RMGGermaniumDetector.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGGermaniumOutputScheme.hh
+++ b/include/RMGGermaniumOutputScheme.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGGrabmayrGCReader.hh
+++ b/include/RMGGrabmayrGCReader.hh
@@ -1,4 +1,5 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Moritz Neuberger <https://orcid.org/0009-0001-8471-9076>
+// Copyright (C) 2024 Eric Esch <https://orcid.org/0009-0000-4920-9313>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGHardware.hh
+++ b/include/RMGHardware.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGHardwareMessenger.hh
+++ b/include/RMGHardwareMessenger.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGIpc.hh
+++ b/include/RMGIpc.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Manuel Huber
+// Copyright (C) 2025 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGIsotopeFilterScheme.hh
+++ b/include/RMGIsotopeFilterScheme.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGLog.hh
+++ b/include/RMGLog.hh
@@ -1,4 +1,20 @@
-// Modified by Luigi Pertoldi <gipert@pm.me> in 2022
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option) any
+// later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+// Modified by Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571> in 2022
 
 #ifndef _RMG_LOG_HH_
 #define _RMG_LOG_HH_

--- a/include/RMGLog.icc
+++ b/include/RMGLog.icc
@@ -1,4 +1,20 @@
-// Modified by Luigi Pertoldi <gipert@pm.me> in 2022
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option) any
+// later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+// Modified by Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571> in 2022
 //
 // Original copyright statement:
 /*

--- a/include/RMGManager.hh
+++ b/include/RMGManager.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGMasterGenerator.hh
+++ b/include/RMGMasterGenerator.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGNavigationTools.hh
+++ b/include/RMGNavigationTools.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGNeutronCaptureProcess.hh
+++ b/include/RMGNeutronCaptureProcess.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Eric Esch <https://orcid.org/0009-0000-4920-9313>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGOpWLSProcess.hh
+++ b/include/RMGOpWLSProcess.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Manuel Huber
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGOpticalDetector.hh
+++ b/include/RMGOpticalDetector.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGOpticalOutputScheme.hh
+++ b/include/RMGOpticalOutputScheme.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGOutputTools.hh
+++ b/include/RMGOutputTools.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Toby Dixon <toby.dixon.23@ucl.ac.uk>
+// Copyright (C) 2025 Toby Dixon <https://orcid.org/0000-0001-8787-6336>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGParticleFilterScheme.hh
+++ b/include/RMGParticleFilterScheme.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Eric Esch <eric.esch@uni-tuebingen.de>
+// Copyright (C) 2025 Eric Esch <https://orcid.org/0009-0000-4920-9313>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGPhysics.hh
+++ b/include/RMGPhysics.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGRun.hh
+++ b/include/RMGRun.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGRunAction.hh
+++ b/include/RMGRunAction.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGScintillatorDetector.hh
+++ b/include/RMGScintillatorDetector.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGScintillatorOutputScheme.hh
+++ b/include/RMGScintillatorOutputScheme.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGStackingAction.hh
+++ b/include/RMGStackingAction.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Manuel Huber
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGSteppingAction.hh
+++ b/include/RMGSteppingAction.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGTools.hh
+++ b/include/RMGTools.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGTrackOutputScheme.hh
+++ b/include/RMGTrackOutputScheme.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGTrackingAction.hh
+++ b/include/RMGTrackingAction.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGUserAction.hh
+++ b/include/RMGUserAction.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGUserInit.hh
+++ b/include/RMGUserInit.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Manuel Huber
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGVGenerator.hh
+++ b/include/RMGVGenerator.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGVOutputScheme.hh
+++ b/include/RMGVOutputScheme.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGVVertexGenerator.hh
+++ b/include/RMGVVertexGenerator.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGVertexConfinement.hh
+++ b/include/RMGVertexConfinement.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGVertexFromFile.hh
+++ b/include/RMGVertexFromFile.hh
@@ -1,5 +1,5 @@
-// Copyright (C) 2024 Manuel Huber
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGVertexOutputScheme.hh
+++ b/include/RMGVertexOutputScheme.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/include/RMGWorkerInitialization.hh
+++ b/include/RMGWorkerInitialization.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGAnalysisReader.cc
+++ b/src/RMGAnalysisReader.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Manuel Huber
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGConvertLH5.cc
+++ b/src/RMGConvertLH5.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Manuel Huber
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGDetectorHit.cc
+++ b/src/RMGDetectorHit.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Toby Dixon <toby.dixon.23@ucl.ac.uk>
+// Copyright (C) 2025 Toby Dixon <https://orcid.org/0000-0001-8787-6336>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGEventAction.cc
+++ b/src/RMGEventAction.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGExceptionHandler.cc
+++ b/src/RMGExceptionHandler.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Manuel Huber
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGGeneratorCosmicMuons.cc
+++ b/src/RMGGeneratorCosmicMuons.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGGeneratorDecay0.cc
+++ b/src/RMGGeneratorDecay0.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGGeneratorFromFile.cc
+++ b/src/RMGGeneratorFromFile.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Manuel Huber
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGGeneratorMUSUNCosmicMuons.cc
+++ b/src/RMGGeneratorMUSUNCosmicMuons.cc
@@ -1,3 +1,19 @@
+// Copyright (C) 2024 Moritz Neuberger <https://orcid.org/0009-0001-8471-9076>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option) any
+// later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
 #include "RMGGeneratorMUSUNCosmicMuons.hh"
 
 #include <cmath>

--- a/src/RMGGeneratorUtil.cc
+++ b/src/RMGGeneratorUtil.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGGermaniumDetector.cc
+++ b/src/RMGGermaniumDetector.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGGermaniumOutputScheme.cc
+++ b/src/RMGGermaniumOutputScheme.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGGrabmayrGCReader.cc
+++ b/src/RMGGrabmayrGCReader.cc
@@ -1,3 +1,20 @@
+// Copyright (C) 2024 Moritz Neuberger <https://orcid.org/0009-0001-8471-9076>
+// Copyright (C) 2024 Eric Esch <https://orcid.org/0009-0000-4920-9313>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option) any
+// later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
 #include "RMGGrabmayrGCReader.hh"
 
 #include "G4Tokenizer.hh"

--- a/src/RMGHardware.cc
+++ b/src/RMGHardware.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGHardwareMessenger.cc
+++ b/src/RMGHardwareMessenger.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGIpc.cc
+++ b/src/RMGIpc.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Manuel Huber
+// Copyright (C) 2025 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGIsotopeFilterScheme.cc
+++ b/src/RMGIsotopeFilterScheme.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGIsotopeFilterScheme.cc
+++ b/src/RMGIsotopeFilterScheme.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGLog.cc
+++ b/src/RMGLog.cc
@@ -1,4 +1,20 @@
-// Modified by Luigi Pertoldi <gipert@pm.me> in 2022
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option) any
+// later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+// Modified by Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571> in 2022
 //
 // Original copyright statement:
 /*

--- a/src/RMGManager.cc
+++ b/src/RMGManager.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGMasterGenerator.cc
+++ b/src/RMGMasterGenerator.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGNavigationTools.cc
+++ b/src/RMGNavigationTools.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGNeutronCaptureProcess.cc
+++ b/src/RMGNeutronCaptureProcess.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Eric Esch <https://orcid.org/0009-0000-4920-9313>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGOpWLSProcess.cc
+++ b/src/RMGOpWLSProcess.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Manuel Huber
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGOpticalDetector.cc
+++ b/src/RMGOpticalDetector.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGOpticalOutputScheme.cc
+++ b/src/RMGOpticalOutputScheme.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGOutputTools.cc
+++ b/src/RMGOutputTools.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Toby Dixon <toby.dixon.23@ucl.ac.uk>
+// Copyright (C) 2025 Toby Dixon <https://orcid.org/0000-0001-8787-6336>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGParticleFilterScheme.cc
+++ b/src/RMGParticleFilterScheme.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Eric Esch <eric.esch@uni-tuebingen.de>
+// Copyright (C) 2025 Eric Esch <https://orcid.org/0009-0000-4920-9313>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGPhysics.cc
+++ b/src/RMGPhysics.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGRunAction.cc
+++ b/src/RMGRunAction.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGScintillatorDetector.cc
+++ b/src/RMGScintillatorDetector.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGScintillatorOutputScheme.cc
+++ b/src/RMGScintillatorOutputScheme.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGStackingAction.cc
+++ b/src/RMGStackingAction.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Manuel Huber
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGSteppingAction.cc
+++ b/src/RMGSteppingAction.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGTrackOutputScheme.cc
+++ b/src/RMGTrackOutputScheme.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGTrackingAction.cc
+++ b/src/RMGTrackingAction.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGUserAction.cc
+++ b/src/RMGUserAction.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGVertexConfinement.cc
+++ b/src/RMGVertexConfinement.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGVertexFromFile.cc
+++ b/src/RMGVertexFromFile.cc
@@ -1,5 +1,5 @@
-// Copyright (C) 2024 Manuel Huber
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/RMGVertexOutputScheme.cc
+++ b/src/RMGVertexOutputScheme.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/remage-doc-dump.cc
+++ b/src/remage-doc-dump.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Manuel Huber
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/remage-from-lh5.cc
+++ b/src/remage-from-lh5.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Manuel Huber
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/remage-to-lh5.cc
+++ b/src/remage-to-lh5.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Manuel Huber
+// Copyright (C) 2024 Manuel Huber <https://orcid.org/0009-0000-5212-2999>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free

--- a/src/remage.cc
+++ b/src/remage.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Luigi Pertoldi <gipert@pm.me>
+// Copyright (C) 2022 Luigi Pertoldi <https://orcid.org/0000-0002-0467-2571>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Lesser General Public License as published by the Free


### PR DESCRIPTION
## Summary
- replace Manuel Huber emails with ORCID links
- remove Manuel Huber attribution from MUSUN cosmic muon generator

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684c003105d0833087d2a4cb187801c9