### PR TITLE
Add docstrings to IPC helper functions

### DIFF
--- a/include/RMGIpc.hh
+++ b/include/RMGIpc.hh
@@ -19,23 +19,45 @@
 #include <atomic>
 #include <string>
 
+/** @brief IPC message sender implementation.
+ *  @details \verbatim embed:rst:leading-asterisk
+ *  .. note ::
+ *      The receiver implementation and message format documentation can be found in
+ *      :py:mod:`remage.ipc`.
+ *  \endverbatim
+ */
 class RMGIpc final {
 
   public:
 
     RMGIpc() = delete;
 
+    /** @brief Set the IPC pipe (write end) file descriptor.
+     */
     static void Setup(int ipc_pipe_fd);
 
+    /** @brief Create an IPC message with a key and a single value.
+     */
     static std::string CreateMessage(const std::string& command, const std::string& param) {
       // \x1e (record separator = end of entry)
       // TODO: also implement a CreateMessage variant with \x1f (unit separator = key/value delimiter)
       return command + "\x1e" + param;
     }
 
+    /** @brief Send a non-blocking IPC message.
+     *  @details The message is a UTF-8 encoded buffer that already contains the message
+     *  structure, such as \ref CreateMessage.
+     */
     static bool SendIpcNonBlocking(std::string msg);
+    /** @brief Send a blocking IPC message.
+     *  @details The message is a UTF-8 encoded buffer that already contains the message
+     *  structure, such as \ref CreateMessage.
+     */
     static bool SendIpcBlocking(std::string msg);
 
+    /** @brief Flag for waiting for the SIGUSR2 signal for blocking messages.
+     *  @details Should not be used by the user and only be set by the signal handler.
+     */
     inline static std::atomic<bool> fWaitForIpc = false;
 
   private:

--- a/python/remage/ipc.py
+++ b/python/remage/ipc.py
@@ -17,11 +17,28 @@ Message parts are separated using ASCII control characters. Each message ends wi
 indicate that the C++ process expects an acknowledgement with a POSIX signal before
 continuing.
 
+Each message must contain at least two records. The first is treated as the
+message's *key*, whereas the second one is the associated value:
+
++-------+--------+---------+-----------+--------+
+| *key* | ``RS`` | *value* | [``ENQ``] | ``GS`` |
++-------+--------+---------+-----------+--------+
+
 Records within a message are delimited by ``RS`` (record separator) and each record
 may contain multiple units split by ``US`` (unit separator). Records with more then
 one unit are returned as tuples on the python side.
 
-Each message must contain at least one record, it is treated as the message's *key*.
+Example: A message
+
++-------+--------+--------+--------+--------+--------+--------+-----------+--------+
+| *key* | ``RS`` | value0 | ``RS`` | value1 | ``US`` | value2 | [``ENQ``] | ``GS`` |
++-------+--------+--------+--------+--------+--------+--------+-----------+--------+
+
+would be decoded to
+
+```python
+["value0", ("value1", "value2")]
+```
 
 Blocking messages
 -----------------

--- a/python/remage/ipc.py
+++ b/python/remage/ipc.py
@@ -84,7 +84,7 @@ def ipc_thread_fn(
     each complete IPC message to :func:`handle_ipc_message` for parsing and
     handling of the associated action. Any message parts will be decoded as
     UTF-8 before parsing.
-    
+
     Blocking messages are acknowledged by sending the POSIX signal ``SIGUSR2``
     to the child  process, while fatal messages trigger ``SIGTERM``. Any
     messages that are not handled by :func:`handle_ipc_message` are appended

--- a/python/remage/ipc.py
+++ b/python/remage/ipc.py
@@ -3,7 +3,7 @@ IPC message receiver implementation for ``remage-cpp``.
 
 .. note ::
 
-    The C++ IPC *sender* implementation can be found in {cpp:class}`RMGIpc`.
+    The C++ IPC *sender* implementation can be found in :cpp:class:`RMGIpc`.
 
 
 Binary message format
@@ -13,20 +13,22 @@ Messages are encoded as UTF-8 strings; transmitting binary (non-string) data wit
 this IPC mechanism is not possible.
 
 Message parts are separated using ASCII control characters. Each message ends with
-``GS`` (group separator) which may be optionally preceded by ``ENQ`` (enquiry) to
-indicate that the C++ process expects an acknowledgement with a POSIX signal before
-continuing.
+``GS`` (group separator, 0x1D) which may be optionally preceded by ``ENQ`` (enquiry,
+0x05) to indicate that the C++ process expects an acknowledgement with a POSIX signal
+before continuing.
 
-Each message must contain at least two records. The first is treated as the
-message's *key*, whereas the second one is the associated value:
+Records within a message are delimited by ``RS`` (record separator, 0x1E). Each
+message must contain at least two records. The first is treated as the message's
+*key*, whereas the second one is the associated *value*:
 
 +-------+--------+---------+-----------+--------+
 | *key* | ``RS`` | *value* | [``ENQ``] | ``GS`` |
 +-------+--------+---------+-----------+--------+
 
-Records within a message are delimited by ``RS`` (record separator) and each record
-may contain multiple units split by ``US`` (unit separator). Records with more then
-one unit are returned as tuples on the python side.
+More values can follow afterwards, again delimited by ``RS``.
+
+Each record may contain multiple units split by ``US`` (unit separator, 0x1F). Records
+with more then one unit are returned as tuples on the python side.
 
 Example: A message
 
@@ -34,11 +36,8 @@ Example: A message
 | *key* | ``RS`` | value0 | ``RS`` | value1 | ``US`` | value2 | [``ENQ``] | ``GS`` |
 +-------+--------+--------+--------+--------+--------+--------+-----------+--------+
 
-would be decoded to
+would be decoded to :code:`["value0", ("value1", "value2")]`.
 
-```python
-["value0", ("value1", "value2")]
-```
 
 Blocking messages
 -----------------

--- a/python/remage/ipc.py
+++ b/python/remage/ipc.py
@@ -3,7 +3,7 @@ IPC message receiver implementation for ``remage-cpp``.
 
 .. note ::
 
-    The C++ IPC *sender* implementation can be found in {cpp}`RMGIpc`.
+    The C++ IPC *sender* implementation can be found in {cpp:class}`RMGIpc`.
 
 
 Binary message format


### PR DESCRIPTION
## Summary
- document the IPC parsing logic and thread handling
- document `IpcResult` helper methods

## Testing
- `ruff check python/remage/ipc.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6851744647c083308079d015d10b6c41