### PR TITLE
Fix an error occuring when setting the vertexgen late with bxdecay0

### DIFF
--- a/include/RMGGeneratorDecay0.hh
+++ b/include/RMGGeneratorDecay0.hh
@@ -21,6 +21,7 @@
 #include "G4GenericMessenger.hh"
 #include "G4ThreeVector.hh"
 
+#include "RMGMasterGenerator.hh"
 #include "RMGVGenerator.hh"
 #include "RMGVVertexGenerator.hh"
 
@@ -75,7 +76,7 @@ class RMGGeneratorDecay0 : public RMGVGenerator {
      *  @param prim_gen Pointer to the remage primary vertex generator.
      *  @details  BxDecay0's primary generator action will own the pointer
      */
-    RMGGeneratorDecay0(RMGVVertexGenerator* prim_gen);
+    RMGGeneratorDecay0(RMGMasterGenerator* master_gen);
     RMGGeneratorDecay0() = delete;
     ~RMGGeneratorDecay0();
 
@@ -93,7 +94,7 @@ class RMGGeneratorDecay0 : public RMGVGenerator {
      *  @details Only does something if any remage set up command was used ( @c fUpdateSeeds is true).
      */
     void BeginOfRunAction(const G4Run*) override;
-    void EndOfRunAction(const G4Run*) override {}
+    void EndOfRunAction(const G4Run*) override;
 
     /** @brief Sets BxDecay0 to run in background mode and sets the specific isotope.
      *  @param isotope The isotope to set (e.g. "Co60").
@@ -104,6 +105,7 @@ class RMGGeneratorDecay0 : public RMGVGenerator {
   private:
 
     std::unique_ptr<bxdecay0_g4::PrimaryGeneratorAction> fDecay0G4Generator;
+    RMGMasterGenerator* fMasterGen = nullptr; // non-owning
 
     std::unique_ptr<G4GenericMessenger> fMessenger = nullptr;
     void DefineCommands();

--- a/include/RMGGeneratorDecay0.hh
+++ b/include/RMGGeneratorDecay0.hh
@@ -73,7 +73,7 @@ class RMGGeneratorDecay0 : public RMGVGenerator {
     };
 
     /** @brief Constructor that links the BxDecay0 generator action to remage.
-     *  @param prim_gen Pointer to the remage primary vertex generator.
+     *  @param master_gen Pointer to the remage master generator.
      *  @details  BxDecay0's primary generator action will own the pointer
      */
     RMGGeneratorDecay0(RMGMasterGenerator* master_gen);

--- a/src/RMGMasterGenerator.cc
+++ b/src/RMGMasterGenerator.cc
@@ -109,8 +109,6 @@ void RMGMasterGenerator::SetGenerator(RMGMasterGenerator::Generator gen) {
     case Generator::kGPS: fGeneratorObj = std::make_unique<RMGGeneratorGPS>(); break;
     case Generator::kBxDecay0:
 #if RMG_HAS_BXDECAY0
-      // NOTE: release ownership here, BxDecay0 will own the pointer (sigh...)
-      // fVertexGeneratorObj will hold nullptr after a call to release()
       fGeneratorObj = std::make_unique<RMGGeneratorDecay0>(this);
 #else
       RMGLog::OutFormat(

--- a/src/RMGMasterGenerator.cc
+++ b/src/RMGMasterGenerator.cc
@@ -111,7 +111,7 @@ void RMGMasterGenerator::SetGenerator(RMGMasterGenerator::Generator gen) {
 #if RMG_HAS_BXDECAY0
       // NOTE: release ownership here, BxDecay0 will own the pointer (sigh...)
       // fVertexGeneratorObj will hold nullptr after a call to release()
-      fGeneratorObj = std::make_unique<RMGGeneratorDecay0>(fVertexGeneratorObj.release());
+      fGeneratorObj = std::make_unique<RMGGeneratorDecay0>(this);
 #else
       RMGLog::OutFormat(
           RMGLog::fatal,

--- a/src/remage-doc-dump.cc
+++ b/src/remage-doc-dump.cc
@@ -34,6 +34,7 @@
 #include "RMGIsotopeFilterScheme.hh"
 #include "RMGLog.hh"
 #include "RMGManager.hh"
+#include "RMGMasterGenerator.hh"
 #include "RMGOpticalOutputScheme.hh"
 #include "RMGParticleFilterScheme.hh"
 #include "RMGScintillatorOutputScheme.hh"
@@ -61,17 +62,13 @@ void init_extra() {
 
   // confinments
   new RMGVertexConfinement();
-#if RMG_HAS_BXDECAY0
-  auto vertex_gen = new RMGVertexFromFile();
-#else
-  new RMGVertexFromFile(); // So the compiler does not complain about unused variable.
-#endif
-
+  new RMGVertexFromFile();
   // generators
   new RMGGeneratorMUSUNCosmicMuons();
   new RMGGeneratorCosmicMuons();
 #if RMG_HAS_BXDECAY0
-  new RMGGeneratorDecay0(vertex_gen); // needs a vertex generator
+  auto master_gen = new RMGMasterGenerator();
+  new RMGGeneratorDecay0(master_gen); // needs a vertex generator
 #endif
   new RMGGeneratorFromFile();
 }


### PR DESCRIPTION
Right now if you use 

```macro
/RMG/Generator/Confine Volume
/RMG/Generator/Confinement/Physical/AddVolume germanium
```
After 
```
/RMG/Generator/Select BxDecay0
```
You will get an error, which is expected due to this line in `RMGGeneratorDecay0.cc`: 
```
if (!prim_gen) RMGLog::OutDev(RMGLog::fatal, "Primary position generator is nullptr")
```

this should be a fix for that and allow for any order of execution, as long as it is called before `/run/beamOn`.

@ManuelHu can you look over this and see if this is a solution we want? It feels kinda hacky, but i am not sure if there is a cleaner solution.