### PR TITLE
remove deprecated localtime calls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,7 @@ include(FetchContent)
 FetchContent_Declare(
   fmt
   GIT_REPOSITORY https://github.com/fmtlib/fmt
-  GIT_TAG 1239137) # 11.1.4
+  GIT_TAG 40626af88bd7df9a5fb80be7b25ac85b122d6c21) # 11.2.0
 FetchContent_MakeAvailable(fmt)
 # fmt is a static lib, make it linkable into libremage.
 # it might also be provided by a system installation, so skip this call in that case.

--- a/src/RMGRunAction.cc
+++ b/src/RMGRunAction.cc
@@ -17,6 +17,7 @@
 
 #include <cstdlib>
 #include <ctime>
+#include <fmt/chrono.h>
 #include <limits>
 #include <random>
 #include <unistd.h>
@@ -31,8 +32,6 @@
 #if RMG_HAS_HDF5
 #include "RMGConvertLH5.hh"
 #endif
-#include <fmt/chrono.h>
-
 #include "RMGEventAction.hh"
 #include "RMGGermaniumOutputScheme.hh"
 #include "RMGIpc.hh"

--- a/src/RMGRunAction.cc
+++ b/src/RMGRunAction.cc
@@ -31,6 +31,8 @@
 #if RMG_HAS_HDF5
 #include "RMGConvertLH5.hh"
 #endif
+#include <fmt/chrono.h>
+
 #include "RMGEventAction.hh"
 #include "RMGGermaniumOutputScheme.hh"
 #include "RMGIpc.hh"
@@ -41,8 +43,6 @@
 #include "RMGOutputManager.hh"
 #include "RMGRun.hh"
 #include "RMGVGenerator.hh"
-
-#include "fmt/chrono.h"
 
 G4Run* RMGRunAction::GenerateRun() {
   fRMGRun = new RMGRun();
@@ -182,13 +182,11 @@ void RMGRunAction::BeginOfRunAction(const G4Run*) {
   fRMGRun->SetStartTime(std::chrono::system_clock::now());
 
   if (this->IsMaster()) {
-    auto tt = fmt::localtime(std::chrono::system_clock::to_time_t(fRMGRun->GetStartTime()));
-
     RMGLog::OutFormat(
         RMGLog::summary,
-        "Starting run nr. {:d}. Current local time is {:%d-%m-%Y %H:%M:%S}",
+        "Starting run nr. {:d}. Current local time is {:%d-%m-%Y %H:%M:%S %Z}",
         fRMGRun->GetRunID(),
-        tt
+        std::chrono::floor<std::chrono::seconds>(fRMGRun->GetStartTime())
     );
     RMGLog::OutFormat(
         RMGLog::summary,
@@ -218,10 +216,11 @@ void RMGRunAction::EndOfRunAction(const G4Run*) {
 
     RMGLog::OutFormat(
         RMGLog::summary,
-        "Run nr. {:d} completed. {:d} events simulated. Current local time is {:%d-%m-%Y %H:%M:%S}",
+        "Run nr. {:d} completed. {:d} events simulated. Current local time is {:%d-%m-%Y %H:%M:%S "
+        "%Z}",
         fRMGRun->GetRunID(),
         n_ev,
-        fmt::localtime(std::chrono::system_clock::to_time_t(time_now))
+        std::chrono::floor<std::chrono::seconds>(time_now)
     );
     if (n_ev != n_ev_requested) {
       RMGLog::OutFormat(


### PR DESCRIPTION
This API is deprecated, which gives us errors building againt latest fmt on conda-forge.

> [!WARNING]
> **Unfortunately this changes the behaviour: the time is now in the _system_ time zone, without any way for the user to override (i.e. by doing `TZ=Europe/Berlin remage ...`, which worked until now)**