### PR TITLE
Allow for setting the random seed via CLI

### DIFF
--- a/src/remage.cc
+++ b/src/remage.cc
@@ -57,6 +57,7 @@ int main(int argc, char** argv) {
   bool version = false;
   bool version_rich = false;
   int nthreads = 1;
+  int rand_seed = -1;
   bool interactive = false;
   bool overwrite_output = false;
   int pipe_fd = -1;
@@ -85,6 +86,7 @@ int main(int argc, char** argv) {
   );
   app.add_flag("-i,--interactive", interactive, "Open an interactive macro command prompt");
   app.add_option("-t,--threads", nthreads, "Set the number of threads used by remage");
+  app.add_option("--rand-seed", rand_seed, "Set the random engine seed")->type_name("INT");
   app.add_option(
          "-g,--gdml-files",
          gdmls,
@@ -147,6 +149,7 @@ int main(int argc, char** argv) {
   manager.SetInteractive(interactive);
   manager.GetOutputManager()->SetOutputOverwriteFiles(overwrite_output);
   manager.SetNumberOfThreads(nthreads);
+  if (rand_seed >= 0) manager.SetRandEngineSeed(rand_seed);
 
   for (const auto& g : gdmls) manager.GetDetectorConstruction()->IncludeGDMLFile(g);
 

--- a/tests/basics/CMakeLists.txt
+++ b/tests/basics/CMakeLists.txt
@@ -23,3 +23,10 @@ add_test(NAME basics/invalid-xml
          COMMAND ${REMAGE_PYEXE} -g gdml/geometry_invalid_xml.gdml -o none --macro-substitutions
                  ENERGY=1000 GENERATOR=GPS -- macros/run.mac)
 set_tests_properties(basics/invalid-xml PROPERTIES WILL_FAIL TRUE)
+
+# verify passing a seed via CLI is handled and logged
+add_test(NAME basics/rand-seed
+         COMMAND ${REMAGE_PYEXE} -g gdml/geometry.gdml -o none --rand-seed 123
+                 --macro-substitutions ENERGY=1000 GENERATOR=GPS -- macros/run.mac)
+set_tests_properties(basics/rand-seed PROPERTIES PASS_REGULAR_EXPRESSION
+                                                 "CLHEP::HepRandom seed set to: 123")


### PR DESCRIPTION
This is needed for the simflow.

- **feat: add --rand-seed option to seed RNG via RMGManager**
- **test: add rand-seed test to verify CLI seed logging**
