### PR TITLE
ci: use python 3.13 on macOS for now

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -182,7 +182,7 @@ jobs:
           brew update
           brew install opencascade cgal gmp mpfr boost
 
-          conda install conda-forge::geant4
+          conda install conda-forge::geant4 "conda-forge::python<3.14"
           echo "CMAKE_PREFIX_PATH=$CONDA_PREFIX" >> $GITHUB_ENV
 
       - name: Build project


### PR DESCRIPTION
many packages do not yet have pre-built wheels for 3.14