### PR TITLE
tests: introduce a new `flaky` label for confinement tests

### DIFF
--- a/tests/confinement/CMakeLists.txt
+++ b/tests/confinement/CMakeLists.txt
@@ -234,7 +234,7 @@ foreach(det ${_solids})
 
   set_tests_properties(
     confinement-surface/relative-fractions-${det}
-    PROPERTIES LABELS extra FIXTURES_REQUIRED confine-surface-${det} ENVIRONMENT
+    PROPERTIES LABELS "extra;flaky" FIXTURES_REQUIRED confine-surface-${det} ENVIRONMENT
                MPLCONFIGDIR=${CMAKE_SOURCE_DIR}/tests)
 
 endforeach()


### PR DESCRIPTION
This is required for managing the tests we run on the conda-forge CI.