### PR TITLE
hotfix: only check gdml in the first process in multi-processing

### DIFF
--- a/src/RMGHardware.cc
+++ b/src/RMGHardware.cc
@@ -66,7 +66,9 @@ G4VPhysicalVolume* RMGHardware::Construct() {
     for (const auto& file : fGDMLFiles) {
       if (!fs::exists(fs::path(file.data()))) RMGLog::Out(RMGLog::fatal, file, " does not exist");
       RMGLog::Out(RMGLog::detail, "Reading ", file, " GDML file");
-      RMGIpc::SendIpcBlocking(RMGIpc::CreateMessage("gdml", file));
+      if (RMGManager::Instance()->GetProcessNumberOffset() == 0) {
+        RMGIpc::SendIpcBlocking(RMGIpc::CreateMessage("gdml", file));
+      }
       parser.Read(file, false);
     }
     fWorld = parser.GetWorldVolume();


### PR DESCRIPTION
this is just a guess, not tested if it actually resolves the issue

fixes #568 