### PR TITLE
Remove the zero energy skip in ScintillatorDetector::ProcessHits

### DIFF
--- a/src/RMGGermaniumDetector.cc
+++ b/src/RMGGermaniumDetector.cc
@@ -57,7 +57,6 @@ bool RMGGermaniumDetector::ProcessHits(G4Step* step, G4TouchableHistory* /*histo
 
   RMGLog::OutDev(RMGLog::debug_event, "Processing germanium detector hits");
 
-  // return if no energy is deposited
   // ignore optical photons
   if (step->GetTrack()->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition()) return false;
 

--- a/src/RMGScintillatorDetector.cc
+++ b/src/RMGScintillatorDetector.cc
@@ -56,8 +56,6 @@ bool RMGScintillatorDetector::ProcessHits(G4Step* step, G4TouchableHistory* /*hi
 
   RMGLog::OutDev(RMGLog::debug_event, "Processing scintillator detector hits");
 
-  // return if no energy is deposited
-  if (step->GetTotalEnergyDeposit() == 0) return false;
   // ignore optical photons
   if (step->GetTrack()->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition()) return false;
 


### PR DESCRIPTION
There is the option and macro `fDiscardZeroEnergyHits` for the Scintillator Outputscheme, but this will not work at the moment, because any hit without energy deposition is currently hard-coded skipped in `RMGScintillatorDetector`. This skip does not exist in `RMGGermaniumDetector` so i think it is a bug