### PR TITLE
tests: use tolerance in more surface confinement comparisons

### DIFF
--- a/tests/confinement/CMakeLists.txt
+++ b/tests/confinement/CMakeLists.txt
@@ -176,53 +176,24 @@ set(_solids tubby box con uni sub trd)
 
 foreach(det ${_solids})
 
-  add_test(
-    NAME confinement-surface/gen-vis-macro-${det}
-    COMMAND /bin/sh -c
-            "sed 's/\${det}/${det}/g' macros/vis-surface.mac > macros/vis-surface-${det}.mac")
-
-  set_tests_properties(
-    confinement-surface/gen-vis-macro-${det}
-    PROPERTIES LABELS "extra;val" FIXTURES_SETUP confine-surface-vis-macro-${det}-fixture
-               FIXTURES_REQUIRED confine-surface-gdml-fixture)
-
   add_test(NAME confinement-surface/${det}-vis
-           COMMAND ${REMAGE_PYEXE} macros/vis-surface-${det}.mac macros/_vis-export.mac -g
+           COMMAND ${REMAGE_PYEXE} macros/vis-surface.mac macros/_vis-export.mac -s det=${det} -g
                    gdml/simple-solids.gdml -o none -l detail)
 
   set_tests_properties(
     confinement-surface/${det}-vis PROPERTIES LABELS "extra;vis;val" FIXTURES_REQUIRED
-                                              confine-surface-vis-macro-${det}-fixture)
+                                              confine-surface-gdml-fixture)
 endforeach()
 
 # run simulations and check
 foreach(det ${_solids})
-
-  add_test(
-    NAME confinement-surface/gen-macro-${det}
-    COMMAND /bin/sh -c
-            "sed 's/\${det}/${det}/g' macros/gen-surface.mac > macros/gen-surface-${det}.mac")
-
-  set_tests_properties(
-    confinement-surface/gen-macro-${det}
-    PROPERTIES LABELS "extra;val" FIXTURES_SETUP confine-surface-macro-${det}-fixture
-               FIXTURES_REQUIRED confine-surface-gdml-fixture)
-
-  add_test(NAME confinement-surface/${det}-gen
-           COMMAND ${REMAGE_PYEXE} macros/gen-surface-${det}.mac -g gdml/simple-solids.gdml -w -l
-                   detail --flat-output -o test-confine-surface-${det}-out.lh5)
-
-  set_tests_properties(
-    confinement-surface/${det}-gen
-    PROPERTIES LABELS "extra;val" FIXTURES_SETUP confine-surface-${det} FIXTURES_REQUIRED
-               confine-surface-macro-${det}-fixture)
 
   add_test(NAME confinement-surface/relative-fractions-${det}
            COMMAND ${PYTHONPATH} ./test_basic_surface.py ${det})
 
   set_tests_properties(
     confinement-surface/relative-fractions-${det}
-    PROPERTIES LABELS "extra;val;flaky" FIXTURES_REQUIRED confine-surface-${det})
+    PROPERTIES LABELS "extra;val;flaky" FIXTURES_REQUIRED confine-surface-gdml-fixture)
 
 endforeach()
 

--- a/tests/confinement/macros/gen-surface.mac
+++ b/tests/confinement/macros/gen-surface.mac
@@ -1,5 +1,5 @@
 /RMG/Output/NtuplePerDetector false
-/RMG/Geometry/RegisterDetector Germanium ${det} 001
+/RMG/Geometry/RegisterDetector Germanium {det} 001
 
 /run/initialize
 
@@ -8,7 +8,7 @@
 /RMG/Generator/Confine Volume
 /RMG/Generator/Confinement/SampleOnSurface true
 
-/RMG/Generator/Confinement/Physical/AddVolume ${det}
+/RMG/Generator/Confinement/Physical/AddVolume {det}
 /RMG/Generator/Confinement/SurfaceSampleMaxIntersections 6
 
 /gps/particle e-

--- a/tests/confinement/macros/vis-surface.mac
+++ b/tests/confinement/macros/vis-surface.mac
@@ -1,5 +1,5 @@
 /RMG/Output/NtuplePerDetector false
-/RMG/Geometry/RegisterDetector Germanium ${det} 001
+/RMG/Geometry/RegisterDetector Germanium {det} 001
 
 /run/initialize
 
@@ -44,7 +44,7 @@
 /RMG/Generator/Confinement/ForceContainmentCheck true
 
 
-/RMG/Generator/Confinement/Physical/AddVolume ${det}
+/RMG/Generator/Confinement/Physical/AddVolume {det}
 /RMG/Generator/Confinement/SurfaceSampleMaxIntersections 6
 
 /gps/particle e-
@@ -53,4 +53,4 @@
 /gps/energy 1 eV
 /run/beamOn 2000
 
-/control/alias export-fn vis-surface-${det}.output
+/control/alias export-fn vis-surface-{det}.output

--- a/tests/confinement/test_basic_surface.py
+++ b/tests/confinement/test_basic_surface.py
@@ -7,6 +7,7 @@ import lh5
 import numpy as np
 import pyg4ometry as pg4
 from matplotlib import pyplot as plt
+from remage import remage_run
 from scipy import stats
 
 plt.rcParams["lines.linewidth"] = 1
@@ -18,6 +19,15 @@ parser.add_argument("det", type=str, help="detector type")
 
 args = parser.parse_args()
 
+remage_run(
+    "macros/gen-surface.mac",
+    gdml_files="gdml/simple-solids.gdml",
+    macro_substitutions={"det": args.det},
+    overwrite_output=True,
+    log_level="detail",
+    flat_output=True,
+    output=f"test-confine-surface-{args.det}-out.lh5",
+)
 
 gdml = "gdml/simple-solids.gdml"
 

--- a/tests/confinement/test_basic_surface.py
+++ b/tests/confinement/test_basic_surface.py
@@ -39,11 +39,14 @@ tol = 1e-6  # mm
 select_sides = {
     "tubby": {
         "func": [
-            lambda x, y, z: (abs(z - 30) < tol) & (np.sqrt(x**2 + y**2) < 60),  # bottom
+            # bottom:
+            lambda x, y, z: (abs(z - 30) < tol) & (np.sqrt(x**2 + y**2) < 60 + tol),
+            # side:
             lambda x, y, z: (
-                (abs(np.sqrt(x**2 + y**2) - 60) < tol) & (abs(z) < 30 - tol)
-            ),  # side
-            lambda x, y, z: (abs(z + 30) < tol) & (np.sqrt(x**2 + y**2) < 60),  # top
+                (abs(np.sqrt(x**2 + y**2) - 60) < tol) & (abs(z) < 30 + tol)
+            ),
+            # top:
+            lambda x, y, z: (abs(z + 30) < tol) & (np.sqrt(x**2 + y**2) < 60 + tol),
         ],
         "area": [
             np.pi * 60**2,
@@ -55,39 +58,45 @@ select_sides = {
     },
     "sub": {
         "func": [
+            # bottom:
             lambda x, y, z: (
                 (abs(z + 30) < tol)
-                & (np.sqrt(x**2 + y**2) < 60)
-                & (np.sqrt(x**2 + y**2) > 20)
-            ),  # bottom
+                & (np.sqrt(x**2 + y**2) < 60 + tol)
+                & (np.sqrt(x**2 + y**2) > 20 - tol)
+            ),
+            # top:
             lambda x, y, z: (
                 (abs(z - 30) < tol)
-                & (np.sqrt(x**2 + y**2) < 60)
-                & (np.sqrt(x**2 + y**2) > 20)
-            ),  # top
+                & (np.sqrt(x**2 + y**2) < 60 + tol)
+                & (np.sqrt(x**2 + y**2) > 20 - tol)
+            ),
+            # outside:
             lambda x, y, z: (
-                (abs(np.sqrt(x**2 + y**2) - 60) < tol) & (abs(z) < 30 - tol)
-            ),  # outside
+                (abs(np.sqrt(x**2 + y**2) - 60) < tol) & (abs(z) < 30 + tol)
+            ),
+            # inside:
             lambda x, y, z: (
-                (abs(np.sqrt(x**2 + y**2) - 20) < tol) & (abs(z) < 30 - tol)
-            ),  # inside
+                (abs(np.sqrt(x**2 + y**2) - 20) < tol) & (abs(z) < 30 + tol)
+            ),
         ],
         "area": [
             np.pi * (60**2 - 20**2),  # bottom
             np.pi * (60**2 - 20**2),  # top
             2 * np.pi * 60 * 60,  # outside
-            2 * np.pi * 60 * 20,
-        ],  # inside
+            2 * np.pi * 60 * 20,  # inside
+        ],
         "order": [1, 2, 3, 0],
         "nice_name": "subtraction of two G4Tubs",
     },
     "con": {
         "func": [
-            lambda x, y, z: (abs(z + 50) < tol) & (np.sqrt(x**2 + y**2) < 60),  # bottom
+            # bottom:
+            lambda x, y, z: (abs(z + 50) < tol) & (np.sqrt(x**2 + y**2) < 60 + tol),
+            # side:
             lambda x, y, z: (
                 (abs(z + 100 * (np.sqrt(x**2 + y**2) / 60) - 50) < tol)
-                & (abs(z) < 50 - tol)
-            ),  # side,
+                & (abs(z) < 50 + tol)
+            ),
         ],
         "area": [
             np.pi * 60**2,  # bottom
@@ -98,43 +107,74 @@ select_sides = {
     },
     "box": {
         "func": [
-            lambda x, y, z: (abs(z - 50) < tol) & (abs(x) < 25) & (abs(y) < 25),  # top
+            # top:
             lambda x, y, z: (
-                (abs(x - 25) < tol) & (abs(y) < 25) & (abs(z) < 50 - tol)
-            ),  # sides
-            lambda x, y, z: (abs(y - 25) < tol) & (abs(x) < 25) & (abs(z) < 50 - tol),
-            lambda x, y, z: (abs(x + 25) < tol) & (abs(y) < 25) & (abs(z) < 50 - tol),
-            lambda x, y, z: (abs(y + 25) < tol) & (abs(x) < 25) & (abs(z) < 50 - tol),
-            lambda x, y, z: (abs(z + 50) < tol) & (abs(x) < 25) & (abs(y) < 25),
-        ],  # bottom
+                (abs(z - 50) < tol) & (abs(x) < 25 + tol) & (abs(y) < 25 + tol)
+            ),
+            # sides:
+            lambda x, y, z: (
+                (abs(x - 25) < tol) & (abs(y) < 25 + tol) & (abs(z) < 50 + tol)
+            ),
+            lambda x, y, z: (
+                (abs(y - 25) < tol) & (abs(x) < 25 + tol) & (abs(z) < 50 + tol)
+            ),
+            lambda x, y, z: (
+                (abs(x + 25) < tol) & (abs(y) < 25 + tol) & (abs(z) < 50 + tol)
+            ),
+            lambda x, y, z: (
+                (abs(y + 25) < tol) & (abs(x) < 25 + tol) & (abs(z) < 50 + tol)
+            ),
+            # bottom:
+            lambda x, y, z: (
+                (abs(z + 50) < tol) & (abs(x) < 25 + tol) & (abs(y) < 25 + tol)
+            ),
+        ],
         "area": [50**2, 100 * 50, 100 * 50, 100 * 50, 100 * 50, 50**2],
         "order": [0, 1, 2, 3, 4, 5],
         "nice_name": "G4Box",
     },
     "uni": {
         "func": [
+            # bottom:
             lambda x, y, z: (
-                (abs(z + 50) < tol) & (abs(x) < 25) & (abs(y) < 25)
-            ),  # bottom
+                (abs(z + 50) < tol) & (abs(x) < 25 + tol) & (abs(y) < 25 + tol)
+            ),
+            # sides:
             lambda x, y, z: (
-                (abs(x - 25) < tol) & (abs(y) < 25) & (abs(z) < 50 - tol)
-            ),  # sides
-            lambda x, y, z: (abs(y - 25) < tol) & (abs(x) < 25) & (abs(z) < 50 - tol),
-            lambda x, y, z: (abs(x + 25) < tol) & (abs(y) < 25) & (abs(z) < 50 - tol),
-            lambda x, y, z: (abs(y + 25) < tol) & (abs(x) < 25) & (abs(z) < 50 - tol),
+                (abs(x - 25) < tol) & (abs(y) < 25 + tol) & (abs(z) < 50 + tol)
+            ),
+            lambda x, y, z: (
+                (abs(y - 25) < tol) & (abs(x) < 25 + tol) & (abs(z) < 50 + tol)
+            ),
+            lambda x, y, z: (
+                (abs(x + 25) < tol) & (abs(y) < 25 + tol) & (abs(z) < 50 + tol)
+            ),
+            lambda x, y, z: (
+                (abs(y + 25) < tol) & (abs(x) < 25 + tol) & (abs(z) < 50 + tol)
+            ),
+            # top:
             lambda x, y, z: (
                 (abs(z - 50) < tol)
-                & (abs(x) < 25)
-                & (abs(y) < 25)
-                & ((abs(x) > 10) | (abs(y) > 10))
-            ),  # top
+                & (abs(x) < 25 + tol)
+                & (abs(y) < 25 + tol)
+                & ((abs(x) > 10 - tol) | (abs(y) > 10 - tol))
+            ),
+            # small sides:
             lambda x, y, z: (
-                (abs(x - 10) < tol) & (abs(y) < 10) & (abs(z - 75) < 25)
-            ),  # small sides
-            lambda x, y, z: (abs(y - 10) < tol) & (abs(x) < 10) & (abs(z - 75) < 25),
-            lambda x, y, z: (abs(x + 10) < tol) & (abs(y) < 10) & (abs(z - 75) < 25),
-            lambda x, y, z: (abs(y + 10) < tol) & (abs(x) < 10) & (abs(z - 75) < 25),
-            lambda x, y, z: (abs(z - 100) < tol) & (abs(x) < 10) & (abs(y) < 10),
+                (abs(x - 10) < tol) & (abs(y) < 10 + tol) & (abs(z - 75) < 25 + tol)
+            ),
+            lambda x, y, z: (
+                (abs(y - 10) < tol) & (abs(x) < 10 + tol) & (abs(z - 75) < 25 + tol)
+            ),
+            lambda x, y, z: (
+                (abs(x + 10) < tol) & (abs(y) < 10 + tol) & (abs(z - 75) < 25 + tol)
+            ),
+            lambda x, y, z: (
+                (abs(y + 10) < tol) & (abs(x) < 10 + tol) & (abs(z - 75) < 25 + tol)
+            ),
+            lambda x, y, z: (
+                (abs(z - 100) < tol) & (abs(x) < 10 + tol) & (abs(y) < 10 + tol)
+            ),
         ],
         "area": [
             50 * 50.0,
@@ -152,32 +192,55 @@ select_sides = {
         "order": [5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 0],
         "nice_name": "Union of two G4Boxs",
     },
-    "trd": {
+    "trd": {  # TODO: the x/y comparisons
         "func": [
-            lambda x, y, z: (abs(z + 50) < tol) & (abs(x) < 25) & (abs(y) < 25),  # base
-            lambda x, y, z: (abs(z - 50) < tol) & (abs(x) < 5) & (abs(y) < 5),  # top
+            # top:
             lambda x, y, z: (
-                (y > 5) & (y < 25) & (y > x) & (y > -x) & (abs(z) < 50 - tol)
-            ),  # sides
+                (abs(z - 50) < tol) & (abs(x) < 5 + tol) & (abs(y) < 5 + tol)
+            ),
+            # sides:
             lambda x, y, z: (
-                (-y > 5) & (-y < 25) & (-y > x) & (-y > -x) & (abs(z) < 50 - tol)
+                (y > 5 - tol)
+                & (y < 25 + tol)
+                & (y > x)
+                & (y > -x)
+                & (abs(z) < 50 + tol)
             ),
             lambda x, y, z: (
-                (x > 5) & (x < 25) & (x > y) & (x > -y) & (abs(z) < 50 - tol)
+                (-y > 5 - tol)
+                & (-y < 25 + tol)
+                & (-y > x)
+                & (-y > -x)
+                & (abs(z) < 50 + tol)
             ),
             lambda x, y, z: (
-                (-x > 5) & (-x < 25) & (-x > y) & (-x > -y) & (abs(z) < 50 - tol)
+                (x > 5 - tol)
+                & (x < 25 + tol)
+                & (x > y)
+                & (x > -y)
+                & (abs(z) < 50 + tol)
+            ),
+            lambda x, y, z: (
+                (-x > 5 - tol)
+                & (-x < 25 + tol)
+                & (-x > y)
+                & (-x > -y)
+                & (abs(z) < 50 + tol)
+            ),
+            # base:
+            lambda x, y, z: (
+                (abs(z + 50) < tol) & (abs(x) < 25 + tol) & (abs(y) < 25 + tol)
             ),
         ],
         "area": [
-            50 * 50.0,
             10 * 10.0,
             np.sqrt(20 * 20 + 100 * 100) * (10 + 50) / 2.0,
             np.sqrt(20 * 20 + 100 * 100) * (10 + 50) / 2.0,
             np.sqrt(20 * 20 + 100 * 100) * (10 + 50) / 2.0,
             np.sqrt(20 * 20 + 100 * 100) * (10 + 50) / 2.0,
+            50 * 50.0,
         ],
-        "order": [1, 2, 4, 3, 5, 0],
+        "order": [0, 1, 3, 2, 4, 5],
         "nice_name": "G4Trapezoid",
     },
 }

--- a/tests/confinement/test_basic_surface.py
+++ b/tests/confinement/test_basic_surface.py
@@ -1,3 +1,15 @@
+"""Surface-confinement test for a set of simple G4 solids.
+
+For each detector type the test:
+  1. runs remage with surface confinement on that solid,
+  2. classifies every generated vertex into one of the solid's faces using
+     the predicates in ``select_sides[det]["func"]``,
+  3. checks that every vertex was assigned to exactly one face,
+  4. compares the fraction of vertices per face against the expected
+     area-weighted fraction via a Poisson likelihood ratio (chi2, N-1 dof)
+     and asserts the resulting significance is < 5 sigma.
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -46,6 +58,26 @@ def add_local_pos(vertices, pos):
 
 
 tol = 1e-6  # mm
+#  - Perpendicular-to-face checks (the coordinate that pins the point to the
+#    face plane, e.g. ``abs(z - 50) < tol``) use a tight ``< tol`` window:
+#    vertices must lie ON the face within floating-point precision.
+#  - In-plane extent checks (e.g. ``abs(x) < 25 + tol``) are *widened* by
+#    ``tol`` so that points landing on an edge shared by two faces satisfy
+#    BOTH adjacent predicates. The classification loop below then assigns
+#    such edge points to the face that appears later in the ``func`` list
+#    (later-wins overwrite), guaranteeing exactly one assignment per vertex
+#    and avoiding flaky "unclassified vertex" failures.
+#  - Inner-bound checks on annular/cutout faces (e.g. ``r > 20 - tol``) are
+#    likewise relaxed so inner edges count.
+
+# Per-detector face definitions. For each detector type:
+#   "func":      list of predicates (one per face) taking local (x, y, z) in mm
+#                and returning a boolean mask of vertices ON that face.
+#   "area":      analytic area of each face, in the same order as "func".
+#                Used to compute the expected fraction per face.
+#   "order":     plot z-order for the 3D/2D scatter plots only (not used for
+#                the statistical test).
+#   "nice_name": label used in plot titles/captions.
 select_sides = {
     "tubby": {
         "func": [
@@ -202,39 +234,41 @@ select_sides = {
         "order": [5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 0],
         "nice_name": "Union of two G4Boxs",
     },
-    "trd": {  # TODO: the x/y comparisons
+    "trd": {
         "func": [
             # top:
             lambda x, y, z: (
                 (abs(z - 50) < tol) & (abs(x) < 5 + tol) & (abs(y) < 5 + tol)
             ),
-            # sides:
+            # sides: diagonal ridges (|x| == |y|) are claimed by both incident
+            # faces via the `- tol` slack; the loop's later-wins rule assigns
+            # each ridge point to exactly one face.
             lambda x, y, z: (
                 (y > 5 - tol)
                 & (y < 25 + tol)
-                & (y > x)
-                & (y > -x)
+                & (y > x - tol)
+                & (y > -x - tol)
                 & (abs(z) < 50 + tol)
             ),
             lambda x, y, z: (
                 (-y > 5 - tol)
                 & (-y < 25 + tol)
-                & (-y > x)
-                & (-y > -x)
+                & (-y > x - tol)
+                & (-y > -x - tol)
                 & (abs(z) < 50 + tol)
             ),
             lambda x, y, z: (
                 (x > 5 - tol)
                 & (x < 25 + tol)
-                & (x > y)
-                & (x > -y)
+                & (x > y - tol)
+                & (x > -y - tol)
                 & (abs(z) < 50 + tol)
             ),
             lambda x, y, z: (
                 (-x > 5 - tol)
                 & (-x < 25 + tol)
-                & (-x > y)
-                & (-x > -y)
+                & (-x > y - tol)
+                & (-x > -y - tol)
                 & (abs(z) < 50 + tol)
             ),
             # base:
@@ -282,6 +316,8 @@ for idx, fun in enumerate(funcs):
         np.array(vertices.ylocal.to_numpy()),
         np.array(vertices.zlocal.to_numpy()),
     )
+    # Later-wins: if a vertex (typically on an edge) satisfies multiple
+    # predicates, it ends up assigned to the face with the highest idx.
     indices[is_close] = idx
 
 if len(indices[indices == -1]) > 0:


### PR DESCRIPTION
change rules:

* $$c > const \quad\rightarrow\quad c > const - tol$$
* $$c < const \quad\rightarrow\quad c < const + tol$$

## more description

two observations from the original code:
* some comparisons did not use the tolarance at all (was that intended?)
* the tolarance actually decreased the amount of points on the edges of any surface. so increasing tol would also increase the statistical failure rate (as we observed in #462...) 

## original comment 

> https://github.com/tdixon97/remage/blob/37644db796633306737e0d877a26d45c422c6750/tests/confinement/test_basic_surface.py#L42-L46
>
> am I stupid or are we not taking into account the `tol` for some of these comparsions, i.e. `(np.sqrt(x**2 + y**2) < 60)`?? Similar for the "middle comparisons" in the boxes case.
>
> And `abs(z) < 30 - tol` is wrong, it should be `abs(z-30)<tol`, right? similar for others

_Originally posted by @ManuelHu in https://github.com/legend-exp/remage/issues/462#issuecomment-4380226585_
            