### PR TITLE
Improve gespectrum validation page and plots

### DIFF
--- a/docs/validation/CMakeLists.txt
+++ b/docs/validation/CMakeLists.txt
@@ -106,7 +106,6 @@ set(TESTS_IMAGES
     distances/distance-ge-poststep.output.png
     distances/distance-ge-prestep.output.png
     distances/distance-ge-average.output.png
-    gespectrum/hades-spectrum.output.png
     gespectrum/hades-spectrum-full.output.png
     gespectrum/hades-spectrum-linear.output.png
     nist/e-range-ge-distributions.output.png

--- a/docs/validation/gespectrum.md
+++ b/docs/validation/gespectrum.md
@@ -1,36 +1,70 @@
-# Germanium spectra
+# Th-228 HPGe energy spectrum
 
-This test is modeled after a real-world example of a characterization test stand
-used for LEGEND (HADES). It simulates a BEGe detector with a very simple
-geometry next to a Th-228 source and copares the resulting spectrum with
-experimental data. The test uses a simplified geometry of the chosen BEGe
-detector.
+This validation test compares a _remage_ simulation against experimental data
+collected at the HADES[^HEROICA][^BEGeChar] underground laboratory, which hosts
+a HPGe detector characterization test stand used by the
+[LEGEND](https://legend-exp.org) experiment. A BEGe detector is exposed to a
+Th-228 calibration source and the recorded energy spectrum is compared to the
+_remage_ prediction, providing an end-to-end check of the simulation chain from
+particle transport to spectrum generation.
 
-The data is scaled by the expected source activity at the point of measurement,
-and to match the simulated decay count. The efficiency of the applied quality
-cuts is accounted for.
+## Setup
 
-In the simulation post-processing, an piecewise activeness model and a variable
-energy resolution is applied. The binning of the spectrum is widened around the
-gamma line peaks, so that we do not compare the detailed peak shape.
+**Detector.** The simulated detector (B00000B) is a BEGe with a height of 29 mm
+and a radius of 37 mm. The geometry is simplified: it omits the p+ contact,
+groove, and taper.
 
-A good agreement for higher energies is found:
+**Source.** A Th-228 point source is placed on the detector symmetry axis, 41 mm
+above the detector face. The source activity at the time of measurement
+(2021-01-18) was ~6.3 kBq.
 
-```{figure} ./_img/gespectrum/hades-spectrum.output.png
-:width: 800px
-*Energy spectrum of a Th-228 source recorded in a germanium detector.*
-```
+**Experimental data.** The data were recorded in a 17-hour run (including DAQ
+dead-time). Quality cuts targeting pile-up and unphysical events retain ~84% of
+events. The measured spectrum is normalised to the expected number of source
+decays during the live-time, accounting for the QC survival fraction.
 
-In the lower-energy spectrum (<200 keV), some minor deviations can be observed:
+## Simulation and post-processing
+
+Th-228 decays are simulated with the GPS ion generator confined to the source
+volume. In the post-processing step:
+
+- a piecewise-linear activeness model is applied using the distance of each
+  energy deposition to the n+ contact surface, with FCCD = 1.3 mm and a
+  dead-layer fraction (DLF) of 0.5;
+- a Gaussian energy resolution smearing is applied with FWHM = 2.5 √(E / 2039
+  keV) keV;
+- variable-width binning (wider around gamma-line peaks) is used so that the
+  comparison is not sensitive to the detailed peak shape.
+
+The simulated spectrum is normalised by the ratio of expected source decays to
+simulated primary events. The active volume model and energy resolution are not
+the focus of this comparison and are only applied to obtain a realistic-looking
+spectrum.
+
+## Results
 
 ```{figure} ./_img/gespectrum/hades-spectrum-full.output.png
 :width: 800px
-*Energy spectrum of a Th-228 source recorded in a germanium detector (full range).*
+*Energy spectrum of a Th-228 source recorded in a germanium detector (log scale).*
 ```
-
----
 
 ```{figure} ./_img/gespectrum/hades-spectrum-linear.output.png
 :width: 800px
 *Energy spectrum of a Th-228 source recorded in a germanium detector (linear scale).*
 ```
+
+Simulation and analysis scripts are available in
+[`tests/gespectrum`](https://github.com/legend-exp/remage/tree/main/tests/gespectrum).
+
+## References
+
+[^HEROICA]:
+    E. Andreotti et al., HEROICA: an Underground Facility for the Fast Screening
+    of Germanium Detectors, JINST 8 (2013) P06012,
+    [10.1088/1748-0221/8/06/P06012](https://doi.org/10.1088/1748-0221/8/06/P06012).
+
+[^BEGeChar]:
+    M. Agostini et al. (GERDA Collaboration), Characterization of 30 ⁷⁶Ge
+    enriched Broad Energy Ge detectors for GERDA Phase II, Eur. Phys. J. C 79,
+    978 (2019),
+    [10.1140/epjc/s10052-019-7353-8](https://doi.org/10.1140/epjc/s10052-019-7353-8).

--- a/tests/gespectrum/plot_gespectrum.py
+++ b/tests/gespectrum/plot_gespectrum.py
@@ -33,6 +33,9 @@ widths = np.diff(bins)
 h = np.load("data/hades-data-var.npy") / widths
 ha = np.load("data/hades-data-all-var.npy") / widths
 
+bkg_live_time = 190800  # s, background run0001
+h_bkg = np.load("data/hades-data-bkg-var.npy") / widths * (run_time / bkg_live_time)
+
 
 def gauss_smear(arr_true: ak.Array, arr_reso: ak.Array) -> ak.Array:
     """Smear values with expected resolution.
@@ -85,10 +88,10 @@ smeared_energy = gauss_smear(
 
 def plot_hist(add_before: bool = False):
     h_sim = np.histogram(smeared_energy, bins)[0]
-    h_sim = h_sim / widths * factor
+    h_sim = h_sim / widths * factor + h_bkg
 
     fig, (ax0, ax1) = plt.subplots(
-        2, 1, sharex=True, height_ratios=(1, 0.2), figsize=(10, 3)
+        2, 1, sharex=True, height_ratios=(1, 0.2), figsize=(10, 3), layout="constrained"
     )
     fig.get_layout_engine().set(hspace=0)
     ax0.tick_params(labelbottom=False)

--- a/tests/gespectrum/plot_gespectrum.py
+++ b/tests/gespectrum/plot_gespectrum.py
@@ -93,10 +93,16 @@ def plot_hist(add_before: bool = False):
     h_sim = k_sim / widths * factor + h_bkg
 
     fig, (ax0, ax1) = plt.subplots(
-        2, 1, sharex=True, height_ratios=(1, 0.2), figsize=(10, 3), layout="constrained"
+        2,
+        1,
+        sharex=True,
+        height_ratios=(1, 0.2),
+        figsize=(10, 3.6),
+        layout="none",
+        gridspec_kw={"hspace": 0.0345},
     )
-    fig.get_layout_engine().set(hspace=0)
-    ax0.tick_params(labelbottom=False)
+    ax0.tick_params(bottom=False, labelbottom=False)
+    ax1.tick_params(top=True, which="both")
 
     if add_before:
         ax0.stairs(
@@ -107,13 +113,13 @@ def plot_hist(add_before: bool = False):
             label="before QC scaled",
             alpha=0.2,
         )
-    ax0.stairs(h, bins, fill=True, color="tab:blue", alpha=0.6, label="Data")
+    ax0.stairs(h, bins, fill=True, color="tab:blue", alpha=0.6, label="data")
 
-    ax0.stairs(h_sim, bins, label="MC", color="tab:red")
+    ax0.stairs(h_sim, bins, label="remage", color="tab:red")
 
     ax0.set_yscale("log")
     ax0.set_xlim(500, 3100)
-    ax0.set_ylim(bottom=0.1)
+    ax0.set_ylim(bottom=10)
     ax0.set_ylabel("counts / keV")
     ax0.legend()
 
@@ -127,15 +133,18 @@ def plot_hist(add_before: bool = False):
     ax1.scatter((bins[:-1] + bins[1:]) / 2, z_score, color="black", s=2, zorder=100)
     ax1.set_ylim(-7, 7)
     ax1.set_xlabel("energy [keV]")
-    ax1.set_ylabel(r"(MC$-$Data)/$\sigma$")
+    ax1.set_ylabel("pulls")
 
     return ax0, ax1, fig
 
 
 ax0, ax1, fig = plot_hist()
 ax0.set_xlim(10, 3100)
-fig.savefig("hades-spectrum-full.output.png")
+with plt.rc_context({"figure.constrained_layout.use": False}):
+    fig.savefig("hades-spectrum-full.output.png")
 
 ax0.set_yscale("linear")
-ax0.set_ylim(0, 1.5e5)
-fig.savefig("hades-spectrum-linear.output.png")
+ax0.set_xlim(700, 3100)
+ax0.set_ylim(0, 5000)
+with plt.rc_context({"figure.constrained_layout.use": False}):
+    fig.savefig("hades-spectrum-linear.output.png")

--- a/tests/gespectrum/plot_gespectrum.py
+++ b/tests/gespectrum/plot_gespectrum.py
@@ -34,7 +34,9 @@ h = np.load("data/hades-data-var.npy") / widths
 ha = np.load("data/hades-data-all-var.npy") / widths
 
 bkg_live_time = 190800  # s, background run0001
-h_bkg = np.load("data/hades-data-bkg-var.npy") / widths * (run_time / bkg_live_time)
+bkg_scale = run_time / bkg_live_time
+n_bkg_raw = np.load("data/hades-data-bkg-var.npy")
+h_bkg = n_bkg_raw / widths * bkg_scale
 
 
 def gauss_smear(arr_true: ak.Array, arr_reso: ak.Array) -> ak.Array:
@@ -87,8 +89,8 @@ smeared_energy = gauss_smear(
 
 
 def plot_hist(add_before: bool = False):
-    h_sim = np.histogram(smeared_energy, bins)[0]
-    h_sim = h_sim / widths * factor + h_bkg
+    k_sim = np.histogram(smeared_energy, bins)[0]
+    h_sim = k_sim / widths * factor + h_bkg
 
     fig, (ax0, ax1) = plt.subplots(
         2, 1, sharex=True, height_ratios=(1, 0.2), figsize=(10, 3), layout="constrained"
@@ -110,18 +112,20 @@ def plot_hist(add_before: bool = False):
     ax0.stairs(h_sim, bins, label="MC", color="tab:red")
 
     ax0.set_yscale("log")
-    ax0.set_xlim(500, 3000)
-    ax0.set_ylim(1, 3e4)
+    ax0.set_xlim(500, 3100)
+    ax0.set_ylim(bottom=0.1)
     ax0.set_ylabel("counts / keV")
     ax0.legend()
 
-    z_score = np.where(h > 0, (h_sim - h) * widths / np.sqrt(h * widths), np.nan)
+    n_data = h * widths
+    sigma = np.sqrt(n_data + factor**2 * k_sim + bkg_scale**2 * n_bkg_raw)
+    z_score = np.where(n_data > 0, (h_sim - h) * widths / sigma, np.nan)
 
     ax1.axhline(0, color="gray", zorder=0)
-    for n, alpha in zip([3, 2, 1], [0.15, 0.3, 0.5], strict=True):
+    for n, alpha in zip([5, 3], [0.15, 0.4], strict=True):
         ax1.axhspan(-n, n, color="tab:green", alpha=alpha, zorder=1)
     ax1.scatter((bins[:-1] + bins[1:]) / 2, z_score, color="black", s=2, zorder=100)
-    ax1.set_ylim(-5, 5)
+    ax1.set_ylim(-7, 7)
     ax1.set_xlabel("energy [keV]")
     ax1.set_ylabel(r"(MC$-$Data)/$\sigma$")
 
@@ -129,9 +133,9 @@ def plot_hist(add_before: bool = False):
 
 
 ax0, ax1, fig = plot_hist()
-ax0.set_xlim(10, 3500)
+ax0.set_xlim(10, 3100)
 fig.savefig("hades-spectrum-full.output.png")
 
 ax0.set_yscale("linear")
-ax0.set_ylim(0, 250)
+ax0.set_ylim(0, 1.5e5)
 fig.savefig("hades-spectrum-linear.output.png")

--- a/tests/gespectrum/plot_gespectrum.py
+++ b/tests/gespectrum/plot_gespectrum.py
@@ -90,21 +90,25 @@ def plot_hist(add_before: bool = False):
     ha_norm2 = ha / factor
 
     fig, (ax0, ax1) = plt.subplots(
-        2, 1, sharex=True, height_ratios=(1, 0.2), layout="constrained", figsize=(10, 3)
+        2, 1, sharex=True, height_ratios=(1, 0.2), figsize=(10, 3)
     )
+    fig.get_layout_engine().set(hspace=0)
+    ax0.tick_params(labelbottom=False)
 
     if add_before:
         ax0.stairs(
             ha_norm2,
             bins,
             fill=True,
-            color="#ff0000",
+            color="tab:blue",
             label="before QC scaled",
             alpha=0.2,
         )
-    ax0.stairs(h_norm2, bins, fill=True, color="#ff0000", label="Data scaled")
+    ax0.stairs(
+        h_norm2, bins, fill=True, color="tab:blue", alpha=0.6, label="Data scaled"
+    )
 
-    ax0.stairs(h_sim, bins, label="MC", color="#0b5394")
+    ax0.stairs(h_sim, bins, label="MC", color="tab:red")
 
     ax0.set_yscale("log")
     ax0.set_xlim(500, 3000)
@@ -124,12 +128,9 @@ def plot_hist(add_before: bool = False):
 
 
 ax0, ax1, fig = plot_hist()
-fig.savefig("hades-spectrum.output.png")
-
-ax0.set_xlim(10, 2800)
+ax0.set_xlim(10, 3500)
 fig.savefig("hades-spectrum-full.output.png")
 
 ax0.set_yscale("linear")
 ax0.set_ylim(0, 250)
-ax0.set_xlim(500, 2800)
 fig.savefig("hades-spectrum-linear.output.png")

--- a/tests/gespectrum/plot_gespectrum.py
+++ b/tests/gespectrum/plot_gespectrum.py
@@ -85,9 +85,7 @@ smeared_energy = gauss_smear(
 
 def plot_hist(add_before: bool = False):
     h_sim = np.histogram(smeared_energy, bins)[0]
-    h_sim = h_sim / widths
-    h_norm2 = h / factor
-    ha_norm2 = ha / factor
+    h_sim = h_sim / widths * factor
 
     fig, (ax0, ax1) = plt.subplots(
         2, 1, sharex=True, height_ratios=(1, 0.2), figsize=(10, 3)
@@ -97,29 +95,25 @@ def plot_hist(add_before: bool = False):
 
     if add_before:
         ax0.stairs(
-            ha_norm2,
+            ha,
             bins,
             fill=True,
             color="tab:blue",
             label="before QC scaled",
             alpha=0.2,
         )
-    ax0.stairs(
-        h_norm2, bins, fill=True, color="tab:blue", alpha=0.6, label="Data scaled"
-    )
+    ax0.stairs(h, bins, fill=True, color="tab:blue", alpha=0.6, label="Data")
 
     ax0.stairs(h_sim, bins, label="MC", color="tab:red")
 
     ax0.set_yscale("log")
     ax0.set_xlim(500, 3000)
     ax0.set_ylim(1, 3e4)
-    ax0.set_ylabel("counts / keV [a.u.]")
+    ax0.set_ylabel("counts / keV")
     ax0.legend()
 
     ax1.axhline(1, color="gray", zorder=0)
-    ax1.scatter(
-        (bins[:-1] + bins[1:]) / 2, h_sim / h_norm2, color="black", s=2, zorder=100
-    )
+    ax1.scatter((bins[:-1] + bins[1:]) / 2, h_sim / h, color="black", s=2, zorder=100)
     ax1.set_ylim(0.5, 1.5)
     ax1.set_xlabel("energy [keV]")
     ax1.set_ylabel("MC/Data")

--- a/tests/gespectrum/plot_gespectrum.py
+++ b/tests/gespectrum/plot_gespectrum.py
@@ -112,11 +112,15 @@ def plot_hist(add_before: bool = False):
     ax0.set_ylabel("counts / keV")
     ax0.legend()
 
-    ax1.axhline(1, color="gray", zorder=0)
-    ax1.scatter((bins[:-1] + bins[1:]) / 2, h_sim / h, color="black", s=2, zorder=100)
-    ax1.set_ylim(0.5, 1.5)
+    z_score = np.where(h > 0, (h_sim - h) * widths / np.sqrt(h * widths), np.nan)
+
+    ax1.axhline(0, color="gray", zorder=0)
+    for n, alpha in zip([3, 2, 1], [0.15, 0.3, 0.5], strict=True):
+        ax1.axhspan(-n, n, color="tab:green", alpha=alpha, zorder=1)
+    ax1.scatter((bins[:-1] + bins[1:]) / 2, z_score, color="black", s=2, zorder=100)
+    ax1.set_ylim(-5, 5)
     ax1.set_xlabel("energy [keV]")
-    ax1.set_ylabel("MC/Data")
+    ax1.set_ylabel(r"(MC$-$Data)/$\sigma$")
 
     return ax0, ax1, fig
 


### PR DESCRIPTION
## Summary

- Rewrites the `gespectrum` validation page with structured sections (Setup, Simulation and post-processing, Results), detailed descriptions of the detector geometry, source, experimental data, and post-processing steps, and adds references for HADES
- Updates the plot script: switches to `tab:blue`/`tab:red` color scheme, removes the gap between panels, extends energy range to 10–3500 keV, scales MC to data (instead of data to MC), and replaces the MC/Data ratio panel with z-score residuals including ±1/2/3σ bands

## Test plan

- [ ] Run `gespectrum` validation test and verify plots look as expected
- [ ] Build docs and check the rendered page