### PR TITLE
python: allow to use the python wrapper with a custom remage-cpp

### DIFF
--- a/docs/manual/extend.md
+++ b/docs/manual/extend.md
@@ -89,3 +89,28 @@ manager.Run();
 This means after {cpp:func}`RMGManager::Run` you can add more custom C++ code
 that you wish to be run after finishing the simulation. For some examples check
 the examples folder.
+
+## Using a custom `remage-cpp` with the stock Python wrapper
+
+When you build your own application as described above, you produce a
+replacement for the `remage-cpp` executable (see
+[That `remage` executable...](../developer.md#that-remage-executable)), but you
+usually still want to drive it through the stock `remage` Python wrapper to keep
+its input pre-processing, LH5 conversion and process-parallel orchestration.
+
+Point the `REMAGE_CPP_PATH` environment variable directly at your executable;
+when set and existing, it takes precedence over the app path burnt into the
+python wrapper:
+
+```console
+$ export REMAGE_CPP_PATH=/path/to/your/build/myapp
+$ remage [options...] macro.mac
+```
+
+Normally the wrapper aborts if the version announced by `remage-cpp` over the
+IPC channel does not exactly match its own. This check is intentionally
+**disabled** when `REMAGE_CPP_PATH` is set, since your application will
+generally report a different version. You are therefore responsible for pairing
+compatible halves: neither the IPC protocol nor the on-disk output layout are
+stable APIs, so build your application against the same _remage_ version as the
+wrapper you drive it with, and update both together.

--- a/python/remage/find_remage.py
+++ b/python/remage/find_remage.py
@@ -30,10 +30,21 @@ def _find_remage_from_config() -> tuple[Path, str] | None:
 
 
 def find_remage_cpp() -> Path:
-    """Find the remage executable, either by using the config stored into the package
-    at build-time or by using the system PATH."""
+    """Find the remage executable to wrap.
 
-    path = _find_remage_from_config()
+    It uses (in order of precedence) the following methods:
+    - the REMAGE_CPP_PATH environment variable pointing to the remage-cpp executable,
+    - the config stored into the package at build-time, or
+    - the system PATH.
+    """
+    path = None
+
+    env_path = os.getenv("REMAGE_CPP_PATH")
+    if env_path is not None and Path(env_path).exists():
+        path = (Path(env_path), "env")
+
+    if path is None:
+        path = _find_remage_from_config()
 
     if path is None:
         which_result = shutil.which("remage-cpp")

--- a/python/remage/ipc.py
+++ b/python/remage/ipc.py
@@ -131,7 +131,7 @@ def handle_ipc_message(
 
         # handle blocking messages, if necessary.
         if fields[0] == "ipc_available":
-            if fields[1] != __version__:
+            if fields[1] != __version__ and os.getenv("REMAGE_CPP_PATH") is None:
                 log.error(
                     "remage-cpp version %s does not match python-wrapper version %s",
                     fields[1],


### PR DESCRIPTION
right now we always claim to be extensible, but this never applied to our python wrapper. So people implementing custom physics etc. could never use that and benefit from all features there.